### PR TITLE
☑️ Randomize tests, improve DB cleaning, load schema

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,12 +84,14 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before(:all) do
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.start
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 
   config.include Devise::Test::ControllerHelpers, type: :controller

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,11 +85,11 @@ RSpec.configure do |config|
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  #   config.order = :random
+  config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
-  #   Kernel.srand config.seed
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
Prior to this commit, our tests ran in the same order.  I found a timing
bug in which data was not being cleared between tests.

With this commit, I'm revising the database cleaning strategy based on
the [documentation][1].  I'm also introducing randomization to better
catch any coupling issues regarding tests.

Last, I'm adding the `load_schema` task suggested by Rob in this [PR][2]

Related to:

- https://github.com/scientist-softserv/viva/pull/46

[1]: https://github.com/DatabaseCleaner/database_cleaner
[2]: https://github.com/scientist-softserv/viva/pull/46