### PR TITLE
🎁 Add questions.data field

### DIFF
--- a/db/migrate/20230911163507_add_data_to_question.rb
+++ b/db/migrate/20230911163507_add_data_to_question.rb
@@ -1,0 +1,5 @@
+class AddDataToQuestion < ActiveRecord::Migration[7.0]
+  def change
+    add_column :questions, :data, :text, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_150410) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_163507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_150410) do
     t.boolean "nested", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "data"
     t.index ["type"], name: "index_questions_on_type"
   end
 


### PR DESCRIPTION
Given that the application is a repository for shareable questions, and
not responsible for prompting users to answer those questions, I don't
think we need worry about the complex modeling.

Instead each question will have a [serializer][1] that is responsible
for loading and dumping the data in an adequate format for the
application logic; namely importing from CSV (however we plan to do
that) and exporting to XML (however we plan to do that).

Related to:

- https://github.com/scientist-softserv/viva/issues/30

[1]: https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize