### PR TITLE
⚙️ Exclude RAILS_ENV from .env

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,6 @@ POSTGRES_DB=viva
 POSTGRES_HOST=postgres
 POSTGRES_PASSWORD=password
 POSTGRES_USER=postgres
-RAILS_ENV=development
 # You would typically use rake secret to generate a secure token. It is
 # critical that you keep this value private in production.
 SECRET_TOKEN=

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,20 +27,6 @@ require 'inertia_rails/rspec'
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
-# Copied from Hyrax; there's an assumption in the Rails 'test' environment that
-# we're running tests in a similar place/state as our development environment.
-# In other words, when we boot rails in test we check the migrations of both
-# test and development.
-#
-# In CI, we don't have a development environment we've worked against, so
-# typically the migrations have not run.  With the following code, we run the
-# development migrations.
-db_config = ActiveRecord::Base.configurations.find_db_config('development')
-ActiveRecord::Tasks::DatabaseTasks.create(db_config)
-ActiveRecord::Migrator.migrations_paths = [Rails.root.join('db', "migrate").to_s]
-ActiveRecord::Tasks::DatabaseTasks.migrate
-ActiveRecord::Base.descendants.each(&:reset_column_information)
-
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION
Prior to this commit, with `RAILS_ENV=development` our tests always ran
against the development environment (which would create some interesting
data deletion issues).

In removing the `RAILS_ENV` from the `.env` file, we are now defaulting
our RAILS_ENV to test.

Related to and supersedes

- https://github.com/scientist-softserv/viva/pull/46