### PR TITLE
🎁 Add SATA question data with serialization

### DIFF
--- a/app/models/question/select_all_that_apply.rb
+++ b/app/models/question/select_all_that_apply.rb
@@ -2,40 +2,12 @@
 
 ##
 # The "Select All That Apply" question has one or more possible correct answers.
-#
-# @example
-#   question = Question::SelectAllThatApply.new(text: "Green::t|Blue::false|Red::1|Yellow::0")
-#   question.data == [["Green", true], ["Blue", false], ["Red", true], ["Yellow", false]]
-#   => true
 class Question::SelectAllThatApply < Question
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.
   serialize :data, JSON
   validate :well_formed_serialized_data
   validates :data, presence: true
-
-  # rubocop:disable Metrics/MethodLength
-  def data=(input)
-    return super unless input.is_a?(String)
-
-    # Instantiating because we're going to use this more than once.
-    caster = ActiveModel::Type::Boolean.new
-
-    # Assuming a CSV.  As we expand this work, we may need to sniff if this is XML.
-    input = input.split(%r{\s*\|\s*}).map do |pair|
-      returning = []
-      pair.strip.split("::").each_with_index do |el, i|
-        returning << if i.odd?
-                       caster.cast(el)
-                     else
-                       el.strip
-                     end
-      end
-      returning
-    end
-    super(input)
-  end
-  # rubocop:enable Metrics/MethodLength
 
   ##
   # Verify that the resulting data attribute is an array with each element being an array of a

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
     factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question
     factory :question_select_all_that_apply, class: Question::SelectAllThatApply, parent: :question do
-      data { "A::t|B::t|C::f" }
+      data { [["A", true], ["B", true], ["C", false]] }
     end
   end
 end

--- a/spec/models/question/select_all_that_apply_spec.rb
+++ b/spec/models/question/select_all_that_apply_spec.rb
@@ -8,48 +8,21 @@ RSpec.describe Question::SelectAllThatApply do
   describe 'data serialization' do
     subject { FactoryBot.build(:question_select_all_that_apply, data:) }
     [
-      [
-        "Green::t|Blue::false|Red::1|Yellow::0",
-        [["Green", true], ["Blue", false], ["Red", true], ["Yellow", false]],
-        true
-      ], [
-        "Green|Blue::false",
-        [["Green"], ["Blue", false]],
-        false
-      ], [
-        "A::t|B::t|C::f",
-        [["A", true], ["B", true], ["C", false]],
-        true
-      ], [
-        nil,
-        nil,
-        false
-      ], [
-        # We only want A::t|B::f format; this is a triple (instead of pair) that is parsed but invalid
-        "Green::t::Yellow|t",
-        [["Green", true, "Yellow"], ["t"]],
-        false
-      ], [
-        "",
-        [],
-        false
-      ],
-      [
-        [["A", true], ["B", false]],
-        [["A", true], ["B", false]],
-        true
-      ], [
-        # TODO: We probably want to enforce that all questions have at least one correct answer.
-        # Highlighting that for now all answers could be incorrect.
-        "Green::false|Blue::false",
-        [["Green", false], ["Blue", false]],
-        true
-      ]
-    ].each do |given, expected, valid|
+      [[["Green"], ["Blue", false]], false],
+      [[["A", true], ["B", true], ["C", false]], true],
+      [nil, false],
+      ["", false],
+      [[], false],
+      # We have a triple and a single.
+      [[["Green", true, "Yellow"], ["t"]], false],
+      # We have two pairs, which should be valid.
+      [[["A", true], ["B", false]], true],
+      # TODO: We probably want to enforce that all questions have at least one correct answer.
+      # Highlighting that for now all answers could be incorrect.
+      [[["Green", false], ["Blue", false]], true]
+    ].each do |given, valid|
       context "when given #{given.inspect}" do
         let(:data) { given }
-
-        its(:data) { is_expected.to eq(expected) }
 
         if valid
           it { is_expected.to be_valid }


### PR DESCRIPTION
## 🎁 Add SATA question data with serialization

f5b864f081ada5b20eff3e777b9983d5a1f0d327

We're recommending that we receive CSVs for ingesting questions.  As
such, we want a way to represent a single cell that would have one or
more pairs for matching.

This is a relatively simple encoding.  My thoughts being that `|` is a
good representative for multi-value.  But we need two different bits of
pairing logic.  Enter the `::` as the other.

 `A::B|C::D` becomes `[["A", "B"] ["C", "D"]]`.

Related to:

- https://github.com/scientist-softserv/viva/issues/30
- https://github.com/scientist-softserv/viva/pull/54

## ♻️ Adjust spec for clarity

bb04d55d51943f15feaa21da6fdfb557249c803a

Co-authored-by: Summer Cook <summer@scientist.com>

## ♻️ Remove compact serialization format

e76f3941814143b69ad5dd7bcef5fb5a434e93ce

Based on conversations the compact serialization format is perhaps not
as user friendly, and might be avoided by thinking through the CSV
column format.

The underlying serialization still matters, which is why that remains.

Co-authored-by: Lea Ann Bradford <ltrammer@gmail.com>
Co-authored-by: Summer Cook <summer@scientist.com>
