### PR TITLE
allow app to startup properly

### DIFF
--- a/docker-compose.override-example.yml
+++ b/docker-compose.override-example.yml
@@ -1,0 +1,11 @@
+# # Copy file to docker-compose.override.yml to override docker-compose.yml
+# # Only use for local development
+# version: '3.8'
+# services:
+#   # Uncomment to allow for the use of a ruby debugger (byebug, pry, etc) in Docker.
+#   # See http://playbook-staging.notch8.com/en/devops/docker_debugger for more info.
+#   web:
+#     command: tail -f /dev/null
+#   postgres:
+#     ports:
+#     - 5432:5432


### PR DESCRIPTION
# story
hide the docker-compose override file so we can start the app again.

yesterday I had problems starting the app with `dc up` or `dc up -d`. I couldn't get `viva.test` to load, although the container showed the server was up. hiding the docker-compose-override file allowed the app to load.

today, summer experienced the same thing.