### PR TITLE
♻️ Remove compact data serialization

### DIFF
--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -3,11 +3,6 @@
 ##
 # A matching {Question}'s data includes pairs (e.g. A goes to B, C goes to D).
 #
-# @example
-#   question = Question::Matching.new(text: "Hello world!", data: "A::B|C::D")
-#   question.data == [["A", "B"], ["C", "D]]
-#   => true
-#
 # @see #well_formed_serialized_data
 class Question::Matching < Question
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
@@ -15,18 +10,6 @@ class Question::Matching < Question
   serialize :data, JSON
   validate :well_formed_serialized_data
   validates :data, presence: true
-
-  ##
-  # @param input [String, Array<Array<String>>] process the data to normalize it for persistence.
-  #        When given a string assume it is a CSV cell and coerce and parse.  Otherwise, use the
-  #        given input directly.  See spec/models/question/matching.rb for more details.
-  def data=(input)
-    return super unless input.is_a?(String)
-
-    # Assuming a CSV.  As we expand this work, we may need to sniff if this is XML.
-    input = input.split(%r{\s*\|\s*}).map { |pair| pair.strip.split("::").map(&:strip) }
-    super(input)
-  end
 
   ##
   # Verify that the resulting data attribute is an array with each element being an array of two

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -8,24 +8,22 @@ RSpec.describe Question::Matching do
   describe 'data serialization' do
     subject { FactoryBot.build(:question_matching, data:) }
     [
-      ["Hello::World|Wonder::Wall", [["Hello", "World"], ["Wonder", "Wall"]], true],
-      ["Hello :: World | Wonder :: Wall", [["Hello", "World"], ["Wonder", "Wall"]], true],
-      ["Hello :: World", [["Hello", "World"]], true],
+      [[["Hello", "World"], ["Wonder", "Wall"]], true],
+      [[["Hello", "World"], ["Wonder", "Wall"]], true],
+      [[["Hello", "World"]], true],
       # When missing the right side of a pairing
-      ["Hello:: |Wonder::Wall", [["Hello"], ["Wonder", "Wall"]], false],
+      [[["Hello"], ["Wonder", "Wall"]], false],
       # When having an empty middle-part
-      ["Hello| |Wonder::Wall", [["Hello"], [], ["Wonder", "Wall"]], false],
-      [nil, nil, false],
-      ["", [], false],
+      [[["Hello"], [], ["Wonder", "Wall"]], false],
+      [nil, false],
+      [[], false],
       # Given an array that is valid
-      [[["Hello", "World"], ["Wonder", "Wall"]], [["Hello", "World"], ["Wonder", "Wall"]], true],
+      [[["Hello", "World"], ["Wonder", "Wall"]], true],
       # Given an array that has a blank value.
-      [[["Hello", ""], ["Wonder", "Wall"]], [["Hello", ""], ["Wonder", "Wall"]], false]
-    ].each do |given, expected, valid|
+      [[["Hello", ""], ["Wonder", "Wall"]], false]
+    ].each do |given, valid|
       context "when given #{given.inspect}" do
         let(:data) { given }
-
-        its(:data) { is_expected.to eq(expected) }
 
         if valid
           it { is_expected.to be_valid }


### PR DESCRIPTION
Prior to this commit, we had a compact serialization format that was
likely more cumbersome for the end-user to create.

With this commit, we're removing that serialization logic.  We'll need
to determine the CSV parsing process to handle this data.

Co-authored-by: Lea Ann Bradford <ltrammer@gmail.com>
Co-authored-by: Summer Cook <summer@scientist.com>