### PR TITLE
🎁 Add traditional question and SATA validation

### DIFF
--- a/app/models/question/select_all_that_apply.rb
+++ b/app/models/question/select_all_that_apply.rb
@@ -12,18 +12,30 @@ class Question::SelectAllThatApply < Question
   ##
   # Verify that the resulting data attribute is an array with each element being an array of a
   # string and boolean.
+  #
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def well_formed_serialized_data
     unless data.is_a?(Array)
       errors.add(:data, "expected to be an array, got #{data.class.inspect}")
       return false
     end
 
-    # TODO: Should we validate that at least one is true?
     unless data.all? { |pair| pair.is_a?(Array) && pair.size == 2 && pair.all? { |el| el.present? && pair.index(el).zero? ? el.is_a?(String) : (el.is_a?(TrueClass) || el.is_a?(FalseClass)) } }
       errors.add(:data, "expected to be an array of arrays, each sub-array having two elements, both of which are strings")
       return false
     end
 
+    # The shape of the data is correct now validate exact number of correct answers.
+    correct_answers = data.select { |pair| pair.last == true }
+
+    if correct_answers.count.zero?
+      errors.add(:data, "expected one correct answer, but no correct answers were specified.")
+      return false
+    end
+
     true
   end
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -4,4 +4,46 @@
 ##
 # One question, many candidate answers, but only one is correct.
 class Question::Traditional < Question
+  # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
+  # for the data to be used in the application, beyond export of data, is minimal.
+  serialize :data, JSON
+  validate :well_formed_serialized_data
+  validates :data, presence: true
+
+  ##
+  # Verify that the resulting data attribute is an array with each element being an array of two
+  # strings.
+  #
+  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  def well_formed_serialized_data
+    unless data.is_a?(Array)
+      errors.add(:data, "expected to be an array, got #{data.class.inspect}")
+      return false
+    end
+
+    unless data.all? { |pair| pair.is_a?(Array) && pair.size == 2 && pair.first.is_a?(String) && (pair.last.is_a?(TrueClass) || pair.last.is_a?(FalseClass)) }
+      errors.add(:data, "expected to be an array of arrays, each sub-array having two elements, the first being a string and the last being a boolean")
+      return false
+    end
+
+    # The shape of the data is correct now validate exact number of correct answers.
+    correct_answers = data.select { |pair| pair.last == true }
+
+    if correct_answers.count.zero?
+      errors.add(:data, "expected one correct answer, but no correct answers were specified.")
+      return false
+    elsif correct_answers.count > 1
+      errors.add(:data, "expected only one correct answer, but instead have #{correct_answers.count} correct answers.")
+      return false
+    end
+
+    true
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
 end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -8,7 +8,10 @@ FactoryBot.define do
     # NOTE: These factory names are based on the class's model_name's param_key which helps with
     # the ./spec/shared_examples.rb
     factory :question_drag_and_drop, class: Question::DragAndDrop, parent: :question
-    factory :question_traditional, class: Question::Traditional, parent: :question
+    factory :question_traditional, class: Question::Traditional, parent: :question do
+      # In this case there are 4 candidate answers and the 3rd one is always correct (always C)
+      data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", i == 3] } }
+    end
     factory :question_matching, class: Question::Matching, parent: :question do
       data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", "Right #{i} #{Faker::Lorem.unique.word}"] } }
     end

--- a/spec/models/question/select_all_that_apply_spec.rb
+++ b/spec/models/question/select_all_that_apply_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe Question::SelectAllThatApply do
       [[["Green", true, "Yellow"], ["t"]], false],
       # We have two pairs, which should be valid.
       [[["A", true], ["B", false]], true],
-      # TODO: We probably want to enforce that all questions have at least one correct answer.
-      # Highlighting that for now all answers could be incorrect.
-      [[["Green", false], ["Blue", false]], true]
+      [[["Green", false], ["Blue", false]], false]
     ].each do |given, valid|
       context "when given #{given.inspect}" do
         let(:data) { given }

--- a/spec/models/question/traditional_spec.rb
+++ b/spec/models/question/traditional_spec.rb
@@ -4,4 +4,35 @@ require 'rails_helper'
 
 RSpec.describe Question::Traditional do
   it_behaves_like "a Question"
+
+  describe 'data serialization' do
+    subject { FactoryBot.build(:question_traditional, data:) }
+    [
+      [[["Green"], ["Blue", false]], false],
+      [[["A", true], ["B", false], ["C", false]], true],
+      # The last element for each pair must be a boolean
+      [[["A", true], ["B", false], ["C", nil]], false],
+      # Disallow more than one correct answer
+      [[["A", true], ["B", true], ["C", false]], false],
+      [nil, false],
+      ["", false],
+      [[], false],
+      # We have a triple and a single.
+      [[["Green", true, "Yellow"], ["t"]], false],
+      # We have two pairs, which should be valid.
+      [[["A", true], ["B", false]], true],
+      [[["Green", false], ["Blue", false]], false],
+      [[["Green", false], ["Blue", true]], true]
+    ].each do |given, valid|
+      context "when given #{given.inspect}" do
+        let(:data) { given }
+
+        if valid
+          it { is_expected.to be_valid }
+        else
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, we considered a SATA question valid when there were no correct answers.

With this commit, we introduce the Traditional question and validate that a SATA must have at least 1 correct answer.

Related to:

- https://github.com/scientist-softserv/viva/issues/30