### PR TITLE
🎁 Add data modeling for StimulusCaseStudy

### DIFF
--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 ##
-# Has many child questions
+# A {Question::StimulusCaseStudy} question is an aggregate of other {Question} records.
 class Question::StimulusCaseStudy < Question
+  has_many :as_parent_question_aggregations,
+           class_name: "QuestionAggregation",
+           inverse_of: :parent_question,
+           dependent: :destroy,
+           as: :parent_question
+  has_many :child_questions, -> { order(presentation_order: :asc) },
+           through: :as_parent_question_aggregations,
+           class_name: "Question",
+           source_type: "Question"
 end

--- a/app/models/question_aggregation.rb
+++ b/app/models/question_aggregation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+##
+# Some questions (e.g. {Question::StimulusCaseStudy}) are composed of other questions.  This join
+# model provides the mechanism for that aggregation.
+class QuestionAggregation < ApplicationRecord
+  belongs_to :parent_question, polymorphic: true
+  belongs_to :child_question, polymorphic: true
+end

--- a/db/migrate/20230913182748_create_question_aggregations.rb
+++ b/db/migrate/20230913182748_create_question_aggregations.rb
@@ -1,0 +1,15 @@
+class CreateQuestionAggregations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :question_aggregations do |t|
+      t.integer :parent_question_id, null: false, foreign_key: true
+      t.string :parent_question_type, null: false
+      t.integer :child_question_id, null: false, foreign_key: true
+      t.string :child_question_type, null: false
+      t.integer :presentation_order, null: false, index: true
+
+      t.timestamps
+    end
+
+    add_index :question_aggregations, [:parent_question_id, :child_question_id, :presentation_order], unique: true, name: :question_aggregations_parent_child_idx
+  end
+end

--- a/db/migrate/20230913192753_change_question_nested_to_child_of_aggregation.rb
+++ b/db/migrate/20230913192753_change_question_nested_to_child_of_aggregation.rb
@@ -1,0 +1,5 @@
+class ChangeQuestionNestedToChildOfAggregation < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :questions, :nested, :child_of_aggregation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_11_163507) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_13_192753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,10 +42,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_163507) do
     t.index ["question_id", "keyword_id"], name: "index_keywords_questions_on_question_id_and_keyword_id", unique: true
   end
 
+  create_table "question_aggregations", force: :cascade do |t|
+    t.integer "parent_question_id", null: false
+    t.string "parent_question_type", null: false
+    t.integer "child_question_id", null: false
+    t.string "child_question_type", null: false
+    t.integer "presentation_order", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_question_id", "child_question_id", "presentation_order"], name: "question_aggregations_parent_child_idx", unique: true
+    t.index ["presentation_order"], name: "index_question_aggregations_on_presentation_order"
+  end
+
   create_table "questions", force: :cascade do |t|
     t.text "text"
     t.string "type", null: false
-    t.boolean "nested", default: false
+    t.boolean "child_of_aggregation", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "data"

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :question do
     text { Faker::Lorem.unique.sentence }
-    nested { false }
+    child_of_aggregation { false }
 
     # NOTE: These factory names are based on the class's model_name's param_key which helps with
     # the ./spec/shared_examples.rb
@@ -15,10 +15,21 @@ FactoryBot.define do
       # In this case there are 4 candidate answers and the 3rd one is always correct (always C)
       data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", i == 3] } }
     end
+
     factory :question_matching, class: Question::Matching, parent: :question do
       data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", "Right #{i} #{Faker::Lorem.unique.word}"] } }
     end
-    factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question
+
+    factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question do
+      after(:build) do |question, _context|
+        child_question_classes = Question.descendants - [question.class]
+        (0..rand(4)).map do |i|
+          child = FactoryBot.build(child_question_classes.sample.model_name.param_key, child_of_aggregation: true)
+          question.as_parent_question_aggregations.build(presentation_order: i, child_question: child)
+        end
+      end
+    end
+
     factory :question_select_all_that_apply, class: Question::SelectAllThatApply, parent: :question do
       data { [["A", true], ["B", true], ["C", false]] }
     end

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -4,4 +4,20 @@ require 'rails_helper'
 
 RSpec.describe Question::StimulusCaseStudy do
   it_behaves_like "a Question"
+
+  it { is_expected.to have_many(:as_parent_question_aggregations) }
+  it { is_expected.to have_many(:child_questions) }
+
+  describe 'factories' do
+    it "generates child questions" do
+      expect do
+        expect do
+          FactoryBot.create(:question_stimulus_case_study)
+        end.to change(Question::StimulusCaseStudy, :count).by(1)
+      end.to change(QuestionAggregation, :count)
+
+      # We want to verify that the factory also creates the child questions
+      expect(Question.where(child_of_aggregation: true).count).to eq(QuestionAggregation.count)
+    end
+  end
 end

--- a/spec/models/question_aggregation_spec.rb
+++ b/spec/models/question_aggregation_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe QuestionAggregation, type: :model do
+  it { is_expected.to belong_to(:child_question) }
+  it { is_expected.to belong_to(:parent_question) }
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Question, type: :model do
   end
 
   describe '.filter' do
+    it 'omits children of question aggregation' do
+      FactoryBot.create(:question_matching, child_of_aggregation: true)
+      expect(described_class.filter).to eq([])
+    end
+
     # rubocop:disable RSpec/ExampleLength
     # rubocop:disable RSpec/MultipleExpectations
     it 'filters by keyword' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -10,6 +10,8 @@ RSpec.shared_examples 'a Question' do |valid: true|
     subject { described_class.new }
     it { is_expected.to have_and_belong_to_many(:categories) }
     it { is_expected.to have_and_belong_to_many(:keywords) }
+    it { is_expected.to have_one(:as_child_question_aggregations) }
+    it { is_expected.to have_one(:parent_question) }
   end
 
   describe 'factories' do


### PR DESCRIPTION
A StimulusCaseStudy begins with some text and is comprised of at least one other question.

With this commit, we model that relation, adjust our factory to create aggregate questions, and add a filter to omit questions that are part of an aggregation.

Related to:

- https://github.com/scientist-softserv/viva/issues/30