### PR TITLE
🎁 Add Question::BowTie

### DIFF
--- a/app/models/question/bow_tie.rb
+++ b/app/models/question/bow_tie.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+##
+# A bow tie {Question}'s structure is as follows:
+#
+#   Left 1 --              -- Right 1
+#            \__ Center __/
+#            |            \
+#   Left N --              -- Right N
+#
+#   Left Candidates: A, B, C, D
+#   Right Candidates: 1, 2, 3, 4
+#   Center Candidates: 𝞪, 𝛃, 𝛅, 𝛄
+#
+# The left and right side can have one or more candidates, and of those candidates one or more
+# correct answers.  The center can have one or more candidates and only one correct answer. (see
+# https://allnurses.com/next-generation-nclex-what-t738934/ for an example)
+#
+# @see #well_formed_serialized_data
+#
+# @example
+#
+#  question = Question::BowTie.new(
+#    text: "Big Question",
+#    data: {
+#      center: { label: "Center Label", answers: [["To Select", true], ["To Skip", false]] },
+#      left: { label: "Left Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+#      right: { label: "Right Label", answers: [["RCorrect", true], ["LIncorrect", false]] }
+#    })
+#
+#   question.valid?
+#   => true
+class Question::BowTie < Question
+  # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
+  # for the data to be used in the application, beyond export of data, is minimal.
+  serialize :data, JSON
+  validate :well_formed_serialized_data
+  validates :data, presence: true
+
+  EXPECTED_DATA_HASH_KEYS = %w[left center right].freeze
+
+  ##
+  # Verify that the resulting data attribute is an array with each element being an array of two
+  # strings.
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
+  def well_formed_serialized_data
+    unless data.is_a?(Hash)
+      errors.add(:data, "expected to be a Hash, got a #{data.class}")
+      return false
+    end
+
+    unless data.keys.map(&:to_s).sort == EXPECTED_DATA_HASH_KEYS.sort
+      errors.add(:data, "expected data Hash keys to be #{EXPECTED_DATA_HASH_KEYS.inspect}, got #{data.keys.inspect}")
+      return false
+    end
+
+    data.keys.each do |key|
+      elements = (data[key.to_s] || data[key.to_sym]).with_indifferent_access
+      break unless __validate_is_a_hash(key, elements)
+      break unless __validate_answers_structure(key, elements[:answers])
+      break unless __validate_label_structure(key, elements[:label])
+
+      if key.to_s == "center"
+        break unless __validate_one_and_only_one_true_answer(key, elements[:answers])
+      else
+        break unless __validate_at_least_one_true_answer(key, elements[:answers])
+      end
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
+
+  private
+
+  def __validate_is_a_hash(key, elements)
+    if elements.is_a?(Hash)
+      return true if elements.key?(:answers) && elements.key?(:label)
+      errors.add(:data, "expected #{key} to be a Hash with keys of 'answers' and 'label'")
+    else
+      errors.add(:data, "expected #{key} to be a Hash, got a #{elements.class}")
+      false
+    end
+  end
+
+  def __validate_answers_structure(key, answers)
+    unless answers.is_a?(Array)
+      errors.add(:data, "expected #{key} answers to be an Array, got #{answers.class}.")
+      return false
+    end
+
+    return true if answers.all? { |element| element.is_a?(Array) && element.size == 2 && element.first.is_a?(String) && (element.last.is_a?(TrueClass) || element.last.is_a?(FalseClass)) }
+    errors.add(:data, "expected #{key} answers to be an Array of Arrays; the sub-array having the first element being a String and the second being a Boolean.")
+
+    false
+  end
+
+  def __validate_one_and_only_one_true_answer(key, answers)
+    count = answers.count { |answer| answer.last == true }
+    return true if count == 1
+
+    errors.add(:data, "expected #{key}'s answers to have one and only one true value; got #{count}.")
+    false
+  end
+
+  def __validate_at_least_one_true_answer(key, answers)
+    return true unless answers.none? { |answer| answer.last == true }
+
+    errors.add(:data, "expected #{key}'s answers to have at least one true value; got none.")
+    false
+  end
+
+  def __validate_label_structure(key, label)
+    return true if label.is_a?(String) && label.present?
+
+    errors.add(:data, "expected #{key}'s label to be a non-blank String")
+    false
+  end
+end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -33,5 +33,13 @@ FactoryBot.define do
     factory :question_select_all_that_apply, class: Question::SelectAllThatApply, parent: :question do
       data { [["A", true], ["B", true], ["C", false]] }
     end
+
+    factory :question_bow_tie, class: Question::BowTie, parent: :question do
+      data do
+        { center: { label: "Center Label", answers: [["To Select", true], ["To Skip", false]] },
+          left: { label: "Center Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+          right: { label: "Center Label", answers: [["RCorrect", true], ["LIncorrect", false]] } }
+      end
+    end
   end
 end

--- a/spec/models/question/bow_tie_spec.rb
+++ b/spec/models/question/bow_tie_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Question::BowTie do
+  it_behaves_like "a Question"
+
+  describe 'data serialization' do
+    subject { FactoryBot.build(:question_bow_tie, data: given_data) }
+
+    [
+      [
+        { center: { label: "The Label", answers: [["To Select", true], ["To Skip", false]] },
+          left: { label: "The Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+          right: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] } },
+        true
+      ], [
+        { center: { label: "", answers: [["To Select", true], ["To Skip", false]] },
+          left: { label: "The Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+          right: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] } },
+        false # Because center label is not present
+      ], [
+        { center: { label: "The Label", answers: [["To Select", true], ["To Skip", true]] },
+          left: { label: "The Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+          right: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] } },
+        false # because the center has more than one true answer
+      ], [
+        { center: { label: "The Label", answers: [["To Select", true, true], ["To Skip", false]] },
+          left: { label: "The Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+          right: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] } },
+        false # because we have a poorly formed center
+      ], [
+        nil, false
+      ], [
+        "", false
+      ], [
+        {}, false # because we don't have the proper keys
+      ], [
+        { center: { label: "The Label", answers: [["To Select", true], ["To Skip", false]] },
+          left: { label: "The Label", answers: [["LCorrect", true], ["LIncorrect", false]] },
+          right: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] },
+          extraneous: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] } },
+        false # because we have extra keys
+      ], [
+        { center: { label: "The Label", answers: [["To Select", false], ["To Skip", false]] },
+          left: [],
+          right: { label: "The Label", answers: [["RCorrect", true], ["LIncorrect", false]] } },
+        false # because the left has entries
+      ]
+    ].each do |data, valid|
+      context "when data is #{data.inspect}" do
+        let(:given_data) { data }
+        if valid
+          it { is_expected.to be_valid }
+        else
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Question, type: :model do
     # rubocop:disable RSpec/ExampleLength
     it do
       is_expected.to(
-        match_array([Question::DragAndDrop,
+        match_array([Question::BowTie,
+                     Question::DragAndDrop,
                      Question::Matching,
                      Question::SelectAllThatApply,
                      Question::StimulusCaseStudy,
@@ -29,6 +30,7 @@ RSpec.describe Question, type: :model do
     it do
       is_expected.to(
         match_array([
+                      "Question::BowTie",
                       "Question::DragAndDrop",
                       "Question::Matching",
                       "Question::SelectAllThatApply",
@@ -55,7 +57,7 @@ RSpec.describe Question, type: :model do
       # setup cost for each individual test.
       question1 = FactoryBot.create(:question_matching)
       question2 = FactoryBot.create(:question_drag_and_drop)
-      question3 = FactoryBot.create(:question_stimulus_case_study)
+      question3 = FactoryBot.create(:question_select_all_that_apply)
       keyword1 = FactoryBot.create(:keyword)
       keyword2 = FactoryBot.create(:keyword)
       keyword3 = FactoryBot.create(:keyword)

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -4,6 +4,7 @@ RSpec.shared_examples 'a Question' do |valid: true|
   describe 'validations' do
     subject { described_class.new }
     it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:type) }
   end
 
   describe 'associations' do


### PR DESCRIPTION
The client provided example of Bow Tie does not match the external
material regarding what a Bow Tie question looks like.  As provided, the
Bow Tie example looks more like a Drag and Drop with a label for the
center value.

The Question::BowTie created follows the format outlined here:
https://allnurses.com/next-generation-nclex-what-t738934/

The reason I chose to implement towards the Bow Tie of the external
resource is that this is more likely to be QML compliant.

Related to:

- https://github.com/scientist-softserv/viva/issues/30