### PR TITLE
🎁 Add Matching CSV format

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -52,7 +52,7 @@ class Question < ApplicationRecord
   end
 
   def self.import_csv_row(*args)
-    raise NotImplementedError, "#{self.class}.#{__method__}"
+    raise NotImplementedError, "#{self}.#{__method__}"
   end
 
   ##

--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -5,6 +5,25 @@
 #
 # @see #well_formed_serialized_data
 class Question::Matching < Question
+  def self.import_csv_row(row)
+    text = row['TEXT']
+
+    # Ensure that we have all of the candidate indices (the left and right side)
+    indices = row.headers.each_with_object([]) do |header, array|
+      next if header.blank?
+      next unless header.start_with?("LEFT_", "RIGHT_")
+      array << header.split(/_+/).last.to_i
+    end.uniq.sort
+
+    data = indices.map do |index|
+      # It is okay that these will possibly be nil; because our downstream validation will catch
+      # them.
+      [row["LEFT_#{index}"], row["RIGHT_#{index}"]]
+    end
+
+    create!(text:, data:)
+  end
+
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.
   serialize :data, JSON

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -5,8 +5,8 @@
 # One question, many candidate answers, but only one is correct.
 class Question::Traditional < Question
   def self.import_csv_row(row)
-    text = row.fetch("TEXT")
-    answers = Array(row.fetch("ANSWERS")).map(&:to_i)
+    text = row['TEXT']
+    answers = Array(row['ANSWERS']).map(&:to_i)
     answer_columns = row.headers.select { |header| header.present? && header.start_with?("ANSWER_") }
     data = answer_columns.map do |col|
       index = col.split(/_+/).last.to_i

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -5,6 +5,24 @@ require 'rails_helper'
 RSpec.describe Question::Matching do
   it_behaves_like "a Question"
 
+  describe '.import_csv_row' do
+    let(:data) do
+      CsvRow.new("TYPE" => "Matching",
+                 "TEXT" => "Matching the proper pariings:",
+                 "LEFT_1" => "Animal",
+                 "RIGHT_1" => "Cat",
+                 "LEFT_2" => "Plant",
+                 "RIGHT_2" => "Catnip")
+    end
+
+    it "creates a matching question" do
+      expect do
+        described_class.import_csv_row(data)
+      end.to change(described_class, :count).by(1)
+      expect(described_class.last.data).to eq([["Animal", "Cat"], ["Plant", "Catnip"]])
+    end
+  end
+
   describe 'data serialization' do
     subject { FactoryBot.build(:question_matching, data:) }
     [

--- a/spec/models/question/traditional_spec.rb
+++ b/spec/models/question/traditional_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Question::Traditional do
       expect do
         described_class.import_csv_row(data)
       end.to change(Question::Traditional, :count).by(1)
+
+      expect(described_class.last.data).to eq([["true", true], ["false", false]])
     end
   end
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -26,14 +26,18 @@ RSpec.describe Question, type: :model do
 
   describe '.import_csv' do
     let(:csv) do
-      CSV.new("TYPE,,TEXT,ANSWERS,ANSWER_1,ANSWER_2\n" \
-                        "Traditional,,Which one is true?,1,true,false", headers: true)
+      CSV.new("TYPE,,TEXT,ANSWERS,ANSWER_1,ANSWER_2,RIGHT_1,LEFT_1\n" \
+              "Traditional,,Which one is true?,1,true,false\n" \
+              "Matching,,Pair Up,,,,Animal,Cat",
+              headers: true)
     end
 
-    it "creates a Traditional question" do
+    it "creates multiple questions" do
       expect do
-        described_class.import_csv(csv)
-      end.to change(Question::Traditional, :count).by(1)
+        expect do
+          described_class.import_csv(csv)
+        end.to change(Question::Traditional, :count).by(1)
+      end.to change(Question::Matching, :count).by(1)
     end
   end
 


### PR DESCRIPTION
This commit adds a rudimentary Matching format that considers the LEFT
and RIGHT pairs.

Also, I changed two things:

1. The NotImplementedError needed to say `#{self}` instead of
   `#{self.class}`; when it was `#{self.class}` it was reporting
   "Class" (because `self` was `Question` and the class of `Question` is
   `Class`).
2. Adding some demonstration of how the CSV maps into the underlying
   data structure.

Closes #82

- https://github.com/scientist-softserv/viva/issues/82