### PR TITLE
🎁 Add Drag and Drop CSV format

### DIFF
--- a/spec/models/question/drag_and_drop_spec.rb
+++ b/spec/models/question/drag_and_drop_spec.rb
@@ -5,6 +5,45 @@ require 'rails_helper'
 RSpec.describe Question::DragAndDrop do
   it_behaves_like "a Question"
 
+  describe '.import_csv_row' do
+    context 'when given slotted data' do
+      let(:data) do
+        CsvRow.new("TYPE" => "Matching",
+                   "TEXT" => "The ___1___ gets high on ___2___:",
+                   "ANSWER_1" => "Cat",
+                   "ANSWER_2" => "Catnip",
+                   "ANSWER_3" => "Blue",
+                   "ANSWER_4" => "Dog")
+      end
+
+      it "creates a drag and drop slotted question" do
+        expect do
+          described_class.import_csv_row(data)
+        end.to change(described_class, :count).by(1)
+        expect(described_class.last.data).to eq([["Cat", 1], ["Catnip", 2], ["Blue", false], ["Dog", false]])
+      end
+    end
+
+    context 'when given non-slotted data' do
+      let(:data) do
+        CsvRow.new("TYPE" => "Matching",
+                   "TEXT" => "Select all of the animals:",
+                   "ANSWERS" => "1,4",
+                   "ANSWER_1" => "Cat",
+                   "ANSWER_2" => "Catnip",
+                   "ANSWER_3" => "Blue",
+                   "ANSWER_4" => "Dog")
+      end
+
+      it "creates a drag and drop slotted question" do
+        expect do
+          described_class.import_csv_row(data)
+        end.to change(described_class, :count).by(1)
+        expect(described_class.last.data).to eq([["Cat", true], ["Catnip", false], ["Blue", false], ["Dog", true]])
+      end
+    end
+  end
+
   describe '#slot_numbers_from_text' do
     subject { FactoryBot.build(:question_drag_and_drop, text:).slot_numbers_from_text }
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -26,19 +26,25 @@ RSpec.describe Question, type: :model do
 
   describe '.import_csv' do
     let(:csv) do
-      CSV.new("TYPE,,TEXT,ANSWERS,ANSWER_1,ANSWER_2,RIGHT_1,LEFT_1\n" \
-              "Traditional,,Which one is true?,1,true,false\n" \
-              "Matching,,Pair Up,,,,Animal,Cat",
+      CSV.new("TYPE,,TEXT,ANSWERS,ANSWER_1,ANSWER_2,RIGHT_1,LEFT_1,ANSWER_3\n" \
+              "Traditional,,Which one is true?,1,true,false,,,Orc\n" \
+              "Matching,,Pair Up,,,,Animal,Cat\n" \
+              "DragAndDrop,,What are Anmials?,\"1,2\",Cat,Dog,,,Shoe\n" \
+              "DragAndDrop,,The ___1___ chases ___2___?,\"1,2\",Cat,Mouse,,,Umbrella\n",
               headers: true)
     end
 
-    it "creates multiple questions" do
+    # rubocop:disable RSpec/ExampleLength
+    it "creates multiple question types" do
       expect do
         expect do
-          described_class.import_csv(csv)
-        end.to change(Question::Traditional, :count).by(1)
-      end.to change(Question::Matching, :count).by(1)
+          expect do
+            described_class.import_csv(csv)
+          end.to change(Question::Traditional, :count).by(1)
+        end.to change(Question::Matching, :count).by(1)
+      end.to change(Question::DragAndDrop, :count).by(2)
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 
   describe '.import_csv_row' do


### PR DESCRIPTION
This commit adds a rudimentary Drag and Drop format that considers both
the slot sub-type and the non-slotted sub-type.

Closes #81

- https://github.com/scientist-softserv/viva/issues/81