### PR TITLE
add-cypress-ci-to-main

### DIFF
--- a/.github/workflows/cypress-chrome-test.yaml
+++ b/.github/workflows/cypress-chrome-test.yaml
@@ -1,0 +1,62 @@
+name: Cypress Chrome Tests
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+jobs:
+  cypress-run-chrome:
+    runs-on: ubuntu-latest
+    name: E2E on Chrome
+    container:
+      image: cypress/browsers:latest
+      options: --user 1001
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+      matrix:
+        containers: [1, 2] # Uses 2 parallel instances
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        # if: ${{ failure() }} # https://github.com/mxschmitt/action-tmate#only-on-failure
+        with:
+          limit-access-to-actor: true
+      - name: Cypress run
+        # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
+        uses: cypress-io/github-action@v6
+        with:
+          browser: chrome
+          # Records to Cypress Cloud
+          record: true
+          # Note: Cypress test parallelization record: true & key to be
+          # set, since this feature requires a Cypress Cloud account.
+          parallel: true
+      # - name: Artifact upload screenshots
+      #   uses: actions/upload-artifact@v3
+      #   # add the line below to store screenshots only on failures
+      #   # if: failure()
+      #   with:
+      #     name: cypress-screenshots
+      #     path: cypress/screenshots
+      #     if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+      # - name: Artifact upload videos
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: cypress-videos
+      #     path: cypress/videos
+      #     if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Need this on main in order for the workflow_dispatch trigger to work for me to get into a tmate debugger session to speed up the ci debugging for cypress test integration through CI
<img width="1018" alt="Screenshot 2023-09-14 at 14 55 05" src="https://github.com/scientist-softserv/viva/assets/63515648/69a5924a-145e-4ac3-936d-71b58bd22e1c">


- #32 