### PR TITLE
🎁 Add keyword_names and category_names to Question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ node_modules
 # cypress
 cypress/screenshots
 cypress/videos
+
+docker-compose.override.yml

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,40 +8,11 @@ class SearchController < ApplicationController
       keywords: Keyword.all.pluck(:name),
       categories: Category.all.pluck(:name),
       types: Question.types,
-      # filtered_questions: Question.filter(
-      #          keywords: params[:keywords],
-      #          categories: params[:categories],
-      #          type: params[:type]
-      #        )
-      filtered_questions: [
-        {
-          id: 1,
-          question: 'What is the meaning of life?',
-          answers: ['This is an answer tothe meaning of life.', 'This is another answer to the meaning of life.', 'This is a third answer to the meaning of life.', 'This is a fourth answer to the meaning of life.'],
-          type: 'Question::Traditional',
-          keywords: ['meaning', 'life'],
-          categories: ['history'],
-          level: '1',
-        },
-        {
-          id: 2,
-          question: 'What is the meaning of life?',
-          answers: ['This is an answer tothe meaning of life.', 'This is another answer to the meaning of life.', 'This is a third answer to the meaning of life.', 'This is a fourth answer to the meaning of life.'],
-          type: 'Question::Traditional',
-          keywords: ['meaning', 'life'],
-          categories: ['history'],
-          level: '1',
-        },
-        {
-          id: 3,
-          question: 'What is the meaning of life?',
-          answers: ['This is an answer tothe meaning of life.', 'This is another answer to the meaning of life.', 'This is a third answer to the meaning of life.', 'This is a fourth answer to the meaning of life.'],
-          type: 'Question::Traditional',
-          keywords: ['meaning', 'life'],
-          categories: ['nursing'],
-          level: '1',
-        },
-      ]
-    }
+      filtered_questions: Question.filter_as_json(
+               keywords: params[:keywords],
+               categories: params[:categories],
+               type: params[:type]
+             )
+           }
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -56,6 +56,57 @@ class Question < ApplicationRecord
   end
 
   ##
+  # @param select [Array<Symbol>] values both passed forward to {.filter} and used to determine the
+  #        JSON properties.
+  # @param kwargs [Hash<Symbol,Object>] values passed forward to {.filter}
+  #
+  # @note Why {.filter} and {.filter_as_json}?  There are two reasons: 1) we are interested in the
+  #       STI field of :type and by default that is not something included in the base {#as_json}
+  #       behavior; 2) we want to include keyword_names and category_names.
+  #
+  #       The keyword_names and category_names are constructed differently so as to minimize
+  #       database queries.  I had tried to use keywords and categories, but those are relations and
+  #       behave a bit differently.  You'll want to look at the specs to see how this resolves.
+  #
+  # @return [Array<Hash>] A Ruby array of hashes where the hashes have the the keys specified in the
+  #         :select parameter.
+  #
+  # @see .filter
+  def self.filter_as_json(select: [:id, :text, :type, :keyword_names, :category_names], **kwargs)
+    filter(select:, **kwargs).as_json(only: select, methods: [:level])
+  end
+
+  ##
+  # @todo A placeholder for future properties/values
+  def level
+    1
+  end
+
+  ##
+  # This method ensures that we will consistently have a Question#keyword_names regardless of
+  # whether the underlying query to reify the Question had a select statement that included the
+  # "keyword_names" query field.
+  #
+  # @return [Array<String>]
+  #
+  # @see .filter_as_json
+  def keyword_names
+    attributes.fetch(:keyword_names) { keywords.map(&:name) } || []
+  end
+
+  ##
+  # This method ensures that we will consistently have a Question#category_names regardless of
+  # whether the underlying query to reify the Question had a select statement that included the
+  # "category_names" query field.
+  #
+  # @return [Array<String>]
+  #
+  # @see .filter_as_json
+  def category_names
+    attributes.fetch(:category_names) { categories.map(&:name) } || []
+  end
+
+  ##
   # Filter questions by keywords and/or categories.
   #
   # We omit questions that are part of a {QuestionAggregation} (e.g. those that are children to a
@@ -65,25 +116,26 @@ class Question < ApplicationRecord
   # @param categories [Array<String>] when provided, a question must have all of the provided
   #        categories.
   # @param type [String,NilClass] when present, filter questions to only include the given type.
-  # @param selected_attributes [Array<Symbol>] the attributes to include in the filter.  By
-  #        narrowing the selection of attributes we reduce the computational cost of generating the
-  #        query result set (e.g. we don't have to serialize/send/deserialize un-used columns.
-  #        *NOTE:* You must include the :type column if you want to leverage the inheritance.
+  # @param select [Array<Symbol>] the attributes to include in the filter.  By narrowing the
+  #        selection of attributes we reduce the computational cost of generating the query result
+  #        set (e.g. we don't have to serialize/send/deserialize un-used columns.  *NOTE:* You must
+  #        include the :type column if you want to leverage the inheritance.
   #
   # @return [ActiveRecord::Relation<Question>] Each {Question} will have only the selected
   #         attributes (e.g. by default they won't have the :created_at, :updated_at, etc
   #         attributes).
   #
+  # @see .filter_as_json
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
-  def self.filter(keywords: [], categories: [], type: nil, selected_attributes: [:id, :text, :type])
+  def self.filter(keywords: [], categories: [], type: nil, select: nil)
     # By wrapping in an array we ensure that our keywords.size and categories.size are counting
     # the number of keywords given and not the number of characters in a singular keyword that was
     # provided.
     keywords = Array.wrap(keywords)
     categories = Array.wrap(categories)
 
-    questions = Question.select(*selected_attributes).where(child_of_aggregation: false)
+    questions = Question.where(child_of_aggregation: false)
 
     if keywords.present?
       # NOTE: This assumes that we don't persist duplicate pairings of question/keyword; this is
@@ -115,7 +167,32 @@ class Question < ApplicationRecord
       questions = questions.where(Arel.sql("id IN (#{categories_subquery.to_sql})"))
     end
 
-    questions
+    return questions if select.blank?
+
+    # The following for category_names and keyword_names is to reduce the number of queries we send
+    # to the database.  By favoring this mechanism we create the virtual attributes of
+    # :category_names and :keyword_names.
+    select_statement = select.clone
+
+    if select.include?(:category_names)
+      select_statement.delete(:category_names)
+      select_statement << %((SELECT ARRAY_AGG (categories.name) AS kws
+        FROM categories
+        INNER JOIN categories_questions ON categories.id = categories_questions.category_id
+        INNER JOIN questions AS inner_q ON categories_questions.question_id = questions.id
+        WHERE inner_q.id = questions.id) AS "category_names")
+    end
+
+    if select.include?(:keyword_names)
+      select_statement.delete(:keyword_names)
+      select_statement << %((SELECT ARRAY_AGG (keywords.name) AS kws
+        FROM keywords
+        INNER JOIN keywords_questions ON keywords.id = keywords_questions.keyword_id
+        INNER JOIN questions AS inner_q ON keywords_questions.question_id = questions.id
+        WHERE inner_q.id = questions.id) AS "keyword_names")
+    end
+
+    questions.select(*select_statement)
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe SearchController do
   describe '#index', inertia: true do
     it "returns a 'Search' component with properties of :keywords, :types, :categories, and :filtered_questions" do
-      question = FactoryBot.create(:question_matching)
+      question = FactoryBot.create(:question_matching, :with_keywords, :with_categories)
+
       user = FactoryBot.create(:user)
       sign_in user
       get :index
@@ -14,7 +15,13 @@ RSpec.describe SearchController do
       expect(inertia.props[:keywords]).to be_a(Array)
       expect(inertia.props[:categories]).to be_a(Array)
       expect(inertia.props[:types]).to be_a(Array)
-      expect(inertia.props[:filtered_questions].as_json).to eq([{ "id" => question.id, "text" => question.text }])
+      expect(inertia.props[:filtered_questions].as_json).to(
+        eq([{ "id" => question.id,
+              "text" => question.text,
+              "type" => question.type,
+              "keyword_names" => question.keywords.map(&:name),
+              "category_names" => question.categories.map(&:name) }])
+      )
     end
   end
 end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -5,19 +5,43 @@ FactoryBot.define do
     text { Faker::Lorem.unique.sentence }
     child_of_aggregation { false }
 
+    ##
+    # See https://thoughtbot.github.io/factory_bot/cookbook/has_and_belongs_to_many-associations.html
+    trait :with_keywords do
+      transient do
+        keyword_count { 1 + rand(3) }
+      end
+
+      keywords do
+        Array.new(keyword_count) { association(:keyword, questions: [instance]) }
+      end
+    end
+
+    ##
+    # See https://thoughtbot.github.io/factory_bot/cookbook/has_and_belongs_to_many-associations.html
+    trait :with_categories do
+      transient do
+        category_count { 1 + rand(2) }
+      end
+
+      categories do
+        Array.new(category_count) { association(:category, questions: [instance]) }
+      end
+    end
+
     # NOTE: These factory names are based on the class's model_name's param_key which helps with
     # the ./spec/shared_examples.rb
     factory :question_drag_and_drop, class: Question::DragAndDrop, parent: :question do
-      data { (1..6).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", i.even?] } }
+      data { (1..6).map { |i| ["Left #{i} #{Faker::Lorem.word}", i.even?] } }
     end
 
     factory :question_traditional, class: Question::Traditional, parent: :question do
       # In this case there are 4 candidate answers and the 3rd one is always correct (always C)
-      data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", i == 3] } }
+      data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.word}", i == 3] } }
     end
 
     factory :question_matching, class: Question::Matching, parent: :question do
-      data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.unique.word}", "Right #{i} #{Faker::Lorem.unique.word}"] } }
+      data { (1..4).map { |i| ["Left #{i} #{Faker::Lorem.word}", "Right #{i} #{Faker::Lorem.word}"] } }
     end
 
     factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question do

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -75,6 +75,47 @@ RSpec.describe Question, type: :model do
     # rubocop:enable RSpec/ExampleLength
   end
 
+  describe '.filter_as_json' do
+    # rubocop:disable RSpec/ExampleLength
+    it 'includes keyword_names and category_names' do
+      question1 = FactoryBot.create(:question_matching, :with_keywords, :with_categories)
+
+      results = described_class.filter_as_json
+
+      expect(results).to(
+        eq([{ id: question1.id,
+              text: question1.text,
+              type: question1.type,
+              level: question1.level,
+              keyword_names: question1.keywords.map(&:name),
+              category_names: question1.categories.map(&:name) }.stringify_keys])
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    context 'when questions have no keywords' do
+      it 'has an empty array for keyword_names' do
+        question = FactoryBot.create(:question_matching)
+        expect(question.keywords).to be_empty
+
+        results = described_class.filter_as_json
+
+        expect(results.first.fetch("keyword_names")).to eq([])
+      end
+    end
+
+    context 'when questions have no categories' do
+      it 'has an empty array for category_names' do
+        question = FactoryBot.create(:question_matching)
+        expect(question.categories).to be_empty
+
+        results = described_class.filter_as_json
+
+        expect(results.first.fetch("category_names")).to eq([])
+      end
+    end
+  end
+
   describe '.filter' do
     it 'omits children of question aggregation' do
       FactoryBot.create(:question_matching, child_of_aggregation: true)

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a Question' do |valid: true|
+  it { is_expected.to respond_to(:keyword_names) }
+  it { is_expected.to respond_to(:category_names) }
+  its(:keyword_names) { is_expected.to be_a(Array) }
+  its(:category_names) { is_expected.to be_a(Array) }
+
   describe 'validations' do
     subject { described_class.new }
     it { is_expected.to validate_presence_of(:text) }
@@ -22,6 +27,27 @@ RSpec.shared_examples 'a Question' do |valid: true|
 
   describe 'factories' do
     subject { FactoryBot.build(described_class.model_name.param_key) }
+
+    describe ":with_keywords trait" do
+      context 'when provided' do
+        subject { FactoryBot.build(described_class.model_name.param_key, :with_keywords) }
+
+        its(:keywords) { is_expected.to be_present }
+      end
+      context 'when not provided' do
+        its(:keywords) { is_expected.not_to be_present }
+      end
+    end
+    describe ":with_categories trait" do
+      context 'when provided' do
+        subject { FactoryBot.build(described_class.model_name.param_key, :with_categories) }
+
+        its(:categories) { is_expected.to be_present }
+      end
+      context 'when not provided' do
+        its(:keywords) { is_expected.not_to be_present }
+      end
+    end
 
     if valid
       it { is_expected.to be_valid }


### PR DESCRIPTION
There are three somewhat inter-related things happening in this commit:

1. Amending `.gitignore`
2. Updating factories to include auto generation of keywords and
   categories.
3. Adding the `Question.filter_as_json` method

In regards to the `.gitignore`, I created a local override file and
don't want to commit that into the repository.  The override was so that
I could use PGAdmin to run SQL queries to test the `Question.filter`
method.  ([see playbook article][1])

In regards to the factories, I wanted to have quick ways to
auto-generate keywords and categories.

Last, the `Question.filter_as_json`.  This is the guts of the change,
namely that the React components are looking to consume the following
attributes for each question returned via the search result: `id`,
`type`, `text`, `keyword_names`, and `category_names`

[1]:  https://playbook-staging.notch8.com/en/dev/database/using-pgadmin-with-docker