### PR TITLE
allow-cypress-ci-to-fail

### DIFF
--- a/.github/workflows/cypress-chrome-test.yaml
+++ b/.github/workflows/cypress-chrome-test.yaml
@@ -16,6 +16,7 @@ on:
 jobs:
   cypress-run-chrome:
     runs-on: ubuntu-latest
+    allow_failure: true
     name: E2E on Chrome
     container:
       image: cypress/browsers:latest


### PR DESCRIPTION
# story
allow the cypress e2e specs to fail.