### PR TITLE
cypress-dont-fail-on-apps-uncaught-exceptions

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,9 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})


### PR DESCRIPTION
Our tests were failing due to an uncaught exception for inertia

documentation: https://docs.cypress.io/api/cypress-api/catalog-of-events#Uncaught-Exceptions

Recent run in ci with error: https://github.com/scientist-softserv/viva/actions/runs/6231221485/job/16912746147

<details><summary>CLICK ME Screenshot</summary>
<img width="1310" alt="Screenshot 2023-09-18 at 22 37 53" src="https://github.com/scientist-softserv/viva/assets/63515648/c72938f9-1e32-4c2a-a6cb-22e3135cf7f4">
</details>

```
TypeError: The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.

  > Cannot read properties of null (reading 'dataset')

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.

https://on.cypress.io/uncaught-exception-from-application
    at exports.createInertiaApp (http://web:3000/vite-dev/@fs/app/node_modules/.vite/deps/@inertiajs_inertia-react.js?v=e5fb397b:4470:119)
    at app (http://web:3000/vite-dev/components/Application.tsx:5:19)
    at HTMLDocument.<anonymous> (http://web:3000/vite-dev/components/Application.tsx:26:3)
```