### PR TITLE
🎁 Add Scenario as possible child for Case Study

### DIFF
--- a/app/models/question/scenario.rb
+++ b/app/models/question/scenario.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# A {Question::Scenario} is a part of a {Question::StimulusCaseStudy}; it introduces the questions
+# that follow.  It does not have answers but is instead interweaved with the other
+# {Question::StimulusCaseStudy.child_questions}.
+class Question::Scenario < Question
+  self.type_label = "Scenario"
+  self.type_name = "Scenario"
+  self.include_in_filterable_type = false
+
+  before_save :always_be_a_child_of_aggregation
+  after_initialize :always_be_a_child_of_aggregation
+
+  def always_be_a_child_of_aggregation
+    self.child_of_aggregation = true
+  end
+end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -44,11 +44,18 @@ FactoryBot.define do
       data { (1..4).map { |i| { answer: "Left #{i} #{Faker::Lorem.word}", correct: "Right #{i} #{Faker::Lorem.word}" } } }
     end
 
+    factory :question_scenario, class: Question::Scenario, parent: :question
+
     factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question do
       after(:build) do |question, _context|
         child_question_classes = Question.descendants - [question.class]
-        (0..rand(4)).map do |i|
-          child = FactoryBot.build(child_question_classes.sample.model_name.param_key, child_of_aggregation: true)
+        (0..5).map do |i|
+          # Injecting some scenarios into the questions.
+          child = if i == 0 || i == 3
+                    FactoryBot.build(:question_scenario)
+                  else
+                    FactoryBot.build(child_question_classes.sample.model_name.param_key, child_of_aggregation: true)
+                  end
           question.as_parent_question_aggregations.build(presentation_order: i, child_question: child)
         end
       end

--- a/spec/models/question/scenario_spec.rb
+++ b/spec/models/question/scenario_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Question::Scenario do
+  it_behaves_like "a Question", test_type_name_to_class: false, include_in_filterable_type: false
+
+  subject { described_class.new }
+
+  its(:child_of_aggregation) { is_expected.to eq(true) }
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Question, type: :model do
     it do
       is_expected.to(
         match_array([Question::BowTie,
+                     Question::Scenario,
                      Question::DragAndDrop,
                      Question::Matching,
                      Question::SelectAllThatApply,
@@ -57,25 +58,6 @@ RSpec.describe Question, type: :model do
     it 'should be implemented by subclasses' do
       expect { described_class.import_csv_row }.to raise_error(NotImplementedError)
     end
-  end
-
-  xdescribe '.types' do
-    subject { described_class.types }
-
-    # rubocop:disable RSpec/ExampleLength
-    it do
-      is_expected.to(
-        match_array([
-                      "Question::BowTie",
-                      "Question::DragAndDrop",
-                      "Question::Matching",
-                      "Question::SelectAllThatApply",
-                      "Question::StimulusCaseStudy",
-                      "Question::Traditional"
-                    ])
-      )
-    end
-    # rubocop:enable RSpec/ExampleLength
   end
 
   describe '.type_name' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a Question' do |valid: true, test_type_name_to_class: true|
+RSpec.shared_examples 'a Question' do |valid: true, test_type_name_to_class: true, include_in_filterable_type: true|
   it { is_expected.to respond_to(:keyword_names) }
   it { is_expected.to respond_to(:category_names) }
   its(:keyword_names) { is_expected.to be_a(Array) }
   its(:category_names) { is_expected.to be_a(Array) }
   its(:type_label) { is_expected.to be_a(String) }
   its(:type_name) { is_expected.to be_a(String) }
+  its(:include_in_filterable_type) { is_expected.to eq(include_in_filterable_type) }
 
   if test_type_name_to_class
     describe '.type_name_to_class' do


### PR DESCRIPTION
Stimulus Case Study questions are of the form:

- Preamble text
- Scenario A
- Question for Scenario A
- Question for Scenario A
- Scenario B
- Question for Scenario A
- Question for Scenario A

That form can be represented by the presentation order modeled via the
QuestionAggregation class (and the resulting relationships).

This work then allows me to model the data for a Stimulus Case Study,
which will be it's own complicated creature.

Related to:

- https://github.com/scientist-softserv/viva/issues/63