### PR TITLE
🎁 Expose Question::StimulusCaseStudy#data

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -74,7 +74,7 @@ class Question < ApplicationRecord
   end
 
   FILTER_DEFAULT_SELECT = [:id, :data, :text, :type, :keyword_names, :category_names].freeze
-  FILTER_DEFAULT_METHODS = [:level, :type_label, :type_name].freeze
+  FILTER_DEFAULT_METHODS = [:level, :type_label, :type_name, :data].freeze
 
   ##
   # @param select [Array<Symbol>] attribute names both passed forward to {.filter} and exposed in
@@ -95,7 +95,14 @@ class Question < ApplicationRecord
   #
   # @see .filter
   def self.filter_as_json(select: FILTER_DEFAULT_SELECT, methods: FILTER_DEFAULT_METHODS, **kwargs)
-    filter(select:, **kwargs).as_json(only: select, methods:)
+    ##
+    # The :data method/field is an interesting creature; we want to "select" it in queries because
+    # in most cases that is adequate.  Yet the {Question::StimulusCaseStudy#data} is unique, in that
+    # it uses the {Question::StimulusCaseStudy#child_questions} to build the data.
+    #
+    # Hence we want to :select that data for querying, but rely instead on the :method.
+    only = select - methods
+    filter(select:, **kwargs).as_json(only:, methods:)
   end
 
   ##

--- a/app/models/question/scenario.rb
+++ b/app/models/question/scenario.rb
@@ -9,10 +9,12 @@ class Question::Scenario < Question
   self.type_name = "Scenario"
   self.include_in_filterable_type = false
 
-  before_save :always_be_a_child_of_aggregation
-  after_initialize :always_be_a_child_of_aggregation
+  before_save :coerce_attributes_to_expected_state
+  after_initialize :coerce_attributes_to_expected_state
 
-  def always_be_a_child_of_aggregation
+  def coerce_attributes_to_expected_state
+    self.data = nil
     self.child_of_aggregation = true
   end
+  private :coerce_attributes_to_expected_state
 end

--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -15,4 +15,26 @@ class Question::StimulusCaseStudy < Question
            through: :as_parent_question_aggregations,
            class_name: "Question",
            source_type: "Question"
+
+  ##
+  # @note Due to the implementation of {Question.filter_as_json} and {Question.filter}, this is not
+  #       performant.  That is it will result in potentially many sub-queries.  One solution would
+  #       be to move the has_many relations to Question but that would expose those methods to other
+  #       question types.
+  #
+  # @return [Array<Hash<String, Object>>] each element will have "type_label", "type_name", and
+  #         "text".  When the child_question has no {#data} it will be omitted (as in a
+  #         {Question::Scenario}).  When the child_question's data is present, it will conform to
+  #         that question's {#data} structure (often an Array but could be a Hash).
+  def data
+    child_questions.map do |question|
+      hash = {
+        "type_label" => question.type_label,
+        "type_name" => question.type_name,
+        "text" => question.text
+      }
+      hash["data"] = question.data if question.data.present?
+      hash
+    end
+  end
 end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -48,7 +48,8 @@ FactoryBot.define do
 
     factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question do
       after(:build) do |question, _context|
-        child_question_classes = Question.descendants - [question.class]
+        child_question_classes = Question.descendants.select(&:include_in_filterable_type?) - [question.class]
+
         (0..5).map do |i|
           # Injecting some scenarios into the questions.
           child = if i == 0 || i == 3

--- a/spec/models/question/scenario_spec.rb
+++ b/spec/models/question/scenario_spec.rb
@@ -4,8 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Question::Scenario do
   it_behaves_like "a Question", test_type_name_to_class: false, include_in_filterable_type: false
+  its(:type_label) { is_expected.to eq("Scenario") }
+  its(:type_name) { is_expected.to eq("Scenario") }
 
   subject { described_class.new }
 
   its(:child_of_aggregation) { is_expected.to eq(true) }
+  its(:data) { is_expected.to be_nil }
 end

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -22,4 +22,20 @@ RSpec.describe Question::StimulusCaseStudy do
       expect(Question.where(child_of_aggregation: true).count).to eq(QuestionAggregation.count)
     end
   end
+
+  describe '#data' do
+    subject { FactoryBot.create(:question_stimulus_case_study).data }
+    it "is comprised of the child_question's metadata" do
+      expect(subject).to be_a(Array)
+
+      # All elements are Hashes
+      expect(subject.all? { |d| d.is_a?(Hash) }).to eq(true)
+
+      # Making an assumption about the factory; namely that the first element is a scenario.
+      expect(subject[0].keys).to match_array(["type_label", "type_name", "text"])
+
+      # The second element is a non-scenario Question, and thus has data.
+      expect(subject[1].keys).to match_array(["type_label", "type_name", "text", "data"])
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, the `Question::StimulusCaseStudy#data` was nil.  In the database we still store that as `nil`.  But, with this commit we now leverage the `Question::StimulusCaseStudy#child_questions` to build the data.

This is then exposed when we render the results of `Question#filter_as_json`.

Related to:

- https://github.com/scientist-softserv/viva/issues/63