### PR TITLE
🚧 Add CSV handling for scenario

### DIFF
--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -61,6 +61,6 @@ class Question::Matching < Question
 
     true
   end
-  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/models/question/scenario.rb
+++ b/app/models/question/scenario.rb
@@ -9,6 +9,23 @@ class Question::Scenario < Question
   self.type_name = "Scenario"
   self.include_in_filterable_type = false
 
+  def self.import_csv_row(row)
+    # TODO: This is naive in that it assumes a full blown object.  It's also highlighting that we're
+    # likely going to want a Csv Importer class; one that can handle the validation then reporting
+    # errors or persisting objects.
+    parent_question = row['PART_OF']
+    create!(text: row['TEXT'], parent_question:)
+  end
+
+  validate :must_have_a_parent_question
+
+  def must_have_a_parent_question
+    # TODO: Consider that we're validating rows of data; and will likely not persist until after we
+    # validate all rows.
+    errors.add(:base, "must have an associated parent question") if parent_question.blank?
+  end
+  private :must_have_a_parent_question
+
   before_save :coerce_attributes_to_expected_state
   after_initialize :coerce_attributes_to_expected_state
 

--- a/app/models/question_aggregation.rb
+++ b/app/models/question_aggregation.rb
@@ -6,4 +6,15 @@
 class QuestionAggregation < ApplicationRecord
   belongs_to :parent_question, polymorphic: true
   belongs_to :child_question, polymorphic: true
+
+  after_initialize :set_default_presentation_order
+
+  ##
+  # There's a database constraint on presentation order; namely it cannot be null.  This
+  # short-circuits that constraint, which is important because our test factories run as part of the
+  # docker build (via db:seed) and those factories are not yet configured to handle the
+  # presentation_order.
+  def set_default_presentation_order
+    self.presentation_order ||= 0
+  end
 end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -51,16 +51,21 @@ FactoryBot.define do
       end
     end
 
-    factory :question_scenario, class: Question::Scenario, parent: :question
+    factory :question_scenario, class: Question::Scenario, parent: :question do
+      parent_question factory: :question_stimulus_case_study_without_children
+    end
 
-    factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question do
+    factory :question_stimulus_case_study_without_children, class: Question::StimulusCaseStudy, parent: :question
+
+    factory :question_stimulus_case_study, parent: :question_stimulus_case_study_without_children do
       after(:build) do |question, _context|
         child_question_classes = Question.descendants.select(&:include_in_filterable_type?) - [question.class]
 
         (0..5).map do |i|
           # Injecting some scenarios into the questions.
           child = if i == 0 || i == 3
-                    FactoryBot.build(:question_scenario)
+                    # If we don't specify the scenario's parent, we'll build an all new one.
+                    FactoryBot.build(:question_scenario, parent_question: question)
                   else
                     FactoryBot.build(child_question_classes.sample.model_name.param_key, child_of_aggregation: true)
                   end

--- a/spec/models/question/scenario_spec.rb
+++ b/spec/models/question/scenario_spec.rb
@@ -11,4 +11,26 @@ RSpec.describe Question::Scenario do
 
   its(:child_of_aggregation) { is_expected.to eq(true) }
   its(:data) { is_expected.to be_nil }
+
+  describe '.import_csv_row' do
+    let(:data) do
+      CsvRow.new("TYPE" => "Scenario",
+                 "TEXT" => "Something Something Scenario",
+                 "PART_OF" => case_study)
+    end
+
+    context 'when provided an existing PART_OF' do
+      let(:case_study) { FactoryBot.build(:question_stimulus_case_study_without_children) }
+      it "creates a scenario question" do
+        expect { described_class.import_csv_row(data) }.to change(described_class, :count).by(1)
+      end
+    end
+
+    context 'when not provided a PART_OF' do
+      let(:case_study) { nil }
+      it "raises an exception" do
+        expect { described_class.import_csv_row(data) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is inadequate as we need our CSV to expose a column that identifies
the importer's "identifying key" and can then reference that.

Ultimately, I need to rethink how we'll do the CSV.
