### PR TITLE
115-type-filtering

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -169,7 +169,9 @@ class Question < ApplicationRecord
     # into a class.  ActiveRecord is smart about Single Table Inheritance (STI).  When we coerce
     # use a subclass of Question there's an implict `where` clause that narrows the query to only
     # that subclass and its descendants.
-    questions = type_name_to_class(type_name, fallback: Question)
+    questions = Question
+    types = Array.wrap(type_name).map { |name| type_name_to_class(name).to_s }
+    questions = questions.where(type: types) if types.present?
 
     questions = questions.where(child_of_aggregation: false)
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe Question, type: :model do
 
       # When given a type it filters to only that type
       expect(described_class.filter(type_name: question1.type_name)).to eq([question1])
+      expect(described_class.filter(type_name: [question1.type_name, question2.type_name])).to eq([question1, question2])
 
       # When given a type and categories that don't overlap
       expect(described_class.filter(type_name: question1.type_name, keywords: [keyword2.name])).to eq([])


### PR DESCRIPTION
# story
filter the types using OR instead of AND

now a user can choose multiple types and get the results that include each type that was selected.
- #115 

