### PR TITLE
🎁 Add Keyword and Category in CSV

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,9 +5,11 @@
 #
 # @note This is an abstract class that leverages single-table inheritance (STI).  There are
 #       subclasses found in the app/models/question directory.
+#
+# rubocop:disable Metrics/ClassLength
 class Question < ApplicationRecord
-  has_and_belongs_to_many :categories
-  has_and_belongs_to_many :keywords
+  has_and_belongs_to_many :categories, -> { order(name: :asc) }
+  has_and_belongs_to_many :keywords, -> { order(name: :asc) }
 
   class_attribute :type_label, default: "Question", instance_writer: false
   class_attribute :type_name, default: "Question", instance_writer: false
@@ -114,6 +116,22 @@ class Question < ApplicationRecord
   end
 
   ##
+  # @param row [CsvRow]
+  # @return [Array<String>]
+  def self.extract_category_names_from(row)
+    row.flat_map { |header, value| value.split(/\s*,\s*/).map(&:strip) if header.present? && (header == "CATEGORIES" || header == "CATEGORY" || header.start_with?("CATEGORY_")) }.compact.sort
+  end
+  private_class_method :extract_category_names_from
+
+  ##
+  # @param row [CsvRow]
+  # @return [Array<String>]
+  def self.extract_keyword_names_from(row)
+    row.flat_map { |header, value| value.split(/\s*,\s*/).map(&:strip) if header.present? && (header == "KEYWORDS" || header == "KEYWORD" || header.start_with?("KEYWORD_")) }.compact.sort
+  end
+  private_class_method :extract_keyword_names_from
+
+  ##
   # This method ensures that we will consistently have a Question#keyword_names regardless of
   # whether the underlying query to reify the Question had a select statement that included the
   # "keyword_names" query field.
@@ -121,9 +139,14 @@ class Question < ApplicationRecord
   # @return [Array<String>]
   #
   # @see .filter_as_json
+  # @see #find_or_create_categories_and_keywords
   def keyword_names
-    attributes.fetch(:keyword_names) { keywords.names } || []
+    @keyword_names.presence || attributes.fetch(:keyword_names) { keywords.map(&:name) } || []
   end
+
+  ##
+  # @see #find_or_create_categories_and_keywords
+  attr_writer :keyword_names
 
   ##
   # This method ensures that we will consistently have a Question#category_names regardless of
@@ -133,8 +156,30 @@ class Question < ApplicationRecord
   # @return [Array<String>]
   #
   # @see .filter_as_json
+  # @see #find_or_create_categories_and_keywords
   def category_names
-    attributes.fetch(:category_names) { categories.names } || []
+    @category_names.presence || attributes.fetch(:category_names) { categories.map(&:name) } || []
+  end
+  ##
+  # @see #find_or_create_categories_and_keywords
+  attr_writer :category_names
+
+  after_save :find_or_create_categories_and_keywords
+
+  ##
+  # As part of the {.build_from_csv_row}, the subclasses are assigning the `@category_names' and
+  # `@keyword_names'.  When we save a record being imported, we want to persist those values to the
+  # corresponding relationships (e.g. {#categories} and {#keywords}).
+  def find_or_create_categories_and_keywords
+    @category_names&.each do |name|
+      categories << Category.find_or_create_by(name:)
+    end
+    @category_names = nil
+
+    @keyword_names&.each do |name|
+      keywords << Keyword.find_or_create_by(name:)
+    end
+    @keyword_names = nil
   end
 
   ##
@@ -167,12 +212,18 @@ class Question < ApplicationRecord
     keywords = Array.wrap(keywords)
     categories = Array.wrap(categories)
 
+    # Specifying a very arbitrary order
+    questions = Question.order(:id)
+
     # We want a human readable name for filtering and UI work.  However, we want to convert that
-    # into a class.  ActiveRecord is smart about Single Table Inheritance (STI).  When we coerce
-    # use a subclass of Question there's an implict `where` clause that narrows the query to only
-    # that subclass and its descendants.
-    questions = Question.order(id: :asc)
-    types = Array.wrap(type_name).map { |name| type_name_to_class(name).to_s }
+    # into a class.  ActiveRecord is mostly smart about Single Table Inheritance (STI).  But we're
+    # not doing something like `Question::Traditional.where`; but instead `Question.where(type:
+    # "Question::Traditional")`.  The below code will ensure that the named type and any child
+    # descendants are used in the where clause.
+    types = Array.wrap(type_name).flat_map do |name|
+      klass = type_name_to_class(name)
+      [klass.sti_name] + klass.descendants.map(&:sti_name)
+    end
     questions = questions.where(type: types) if types.present?
 
     questions = questions.where(child_of_aggregation: false)
@@ -233,3 +284,5 @@ class Question < ApplicationRecord
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 end
+
+# rubocop:enable Metrics/ClassLength

--- a/app/models/question/drag_and_drop.rb
+++ b/app/models/question/drag_and_drop.rb
@@ -28,9 +28,11 @@ class Question::DragAndDrop < Question
   # rubocop:disable Metrics/PerceivedComplexity
   def self.build_row(row)
     text = row['TEXT']
+    category_names = extract_category_names_from(row)
+    keyword_names = extract_keyword_names_from(row)
 
     # We need to sniff out the subtype and handle accordingly.
-    record = new(text:)
+    record = new(text:, keyword_names:, category_names:)
 
     if record.sub_type == SUB_TYPE_SLOTTED
       slot_numbers = record.slot_numbers_from_text

--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -9,6 +9,8 @@ class Question::Matching < Question
 
   def self.build_row(row)
     text = row['TEXT']
+    category_names = extract_category_names_from(row)
+    keyword_names = extract_keyword_names_from(row)
 
     # Ensure that we have all of the candidate indices (the left and right side)
     indices = row.headers.each_with_object([]) do |header, array|
@@ -25,7 +27,7 @@ class Question::Matching < Question
       { answer:, correct: }
     end
 
-    new(text:, data:)
+    new(text:, data:, category_names:, keyword_names:)
   end
 
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need

--- a/app/models/question/select_all_that_apply.rb
+++ b/app/models/question/select_all_that_apply.rb
@@ -7,6 +7,9 @@ class Question::SelectAllThatApply < Question
 
   def self.build_row(row)
     text = row['TEXT']
+    category_names = extract_category_names_from(row)
+    keyword_names = extract_keyword_names_from(row)
+
     answers = row['ANSWERS']&.split(',')&.map(&:to_i)
     answer_columns = row.headers.select { |header| header.present? && header.start_with?("ANSWER_") }
     data = answer_columns.map do |col|
@@ -14,7 +17,7 @@ class Question::SelectAllThatApply < Question
       { answer: row[col], correct: answers.include?(index) }
     end
 
-    new(text:, data:)
+    new(text:, data:, category_names:, keyword_names:)
   end
 
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -8,14 +8,17 @@ class Question::Traditional < Question
 
   def self.build_row(row)
     text = row['TEXT']
-    answers = row['ANSWERS']&.split(',')&.map(&:to_i)
+    answers = row['ANSWERS']&.split(/\s*,\s*/)&.map(&:to_i)
+    category_names = extract_category_names_from(row)
+    keyword_names = extract_keyword_names_from(row)
     answer_columns = row.headers.select { |header| header.present? && header.start_with?("ANSWER_") }
+
     data = answer_columns.map do |col|
       index = col.split(/_+/).last.to_i
       { answer: row[col], correct: answers.include?(index) }
     end
 
-    new(text:, data:)
+    new(text:, data:, category_names:, keyword_names:)
   end
 
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need

--- a/spec/fixtures/files/valid_questions.csv
+++ b/spec/fixtures/files/valid_questions.csv
@@ -1,2 +1,2 @@
-IMPORT_ID,TYPE, TEXT, ANSWERS, ANSWER_1, ANSWER_2
-1,Traditional, Is true is often considered true?,1,Yes,No
+IMPORT_ID,TYPE, TEXT, ANSWERS, ANSWER_1, ANSWER_2, KEYWORD_1, KEYWORD_2, CATEGORY_1, CATEGORY_2
+1,Traditional, Is true is often considered true?,1,Yes,No,Boolean,True/False,Philosophy,Metaphysics

--- a/spec/models/question/drag_and_drop_spec.rb
+++ b/spec/models/question/drag_and_drop_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Question::DragAndDrop do
                    "ANSWER_1" => "Cat",
                    "ANSWER_2" => "Catnip",
                    "ANSWER_3" => "Blue",
-                   "ANSWER_4" => "Dog")
+                   "ANSWER_4" => "Dog",
+                   "KEYWORD" => "One, Two",
+                   "CATEGORY" => "Big, Little")
       end
 
       it { is_expected.to be_valid }
@@ -25,6 +27,13 @@ RSpec.describe Question::DragAndDrop do
       its(:data) do
         is_expected.to eq([{ "answer" => "Cat", "correct" => 1 }, { 'answer' => "Catnip", "correct" => 2 }, { 'answer' => "Blue", 'correct' => false },
                            { 'answer' => "Dog", 'correct' => false }])
+      end
+
+      context 'when saved' do
+        before { subject.save }
+
+        its(:keyword_names) { is_expected.to match_array(["One", "Two"]) }
+        its(:category_names) { is_expected.to match_array(["Big", "Little"]) }
       end
     end
 
@@ -36,7 +45,9 @@ RSpec.describe Question::DragAndDrop do
                    "ANSWER_1" => "Cat",
                    "ANSWER_2" => "Catnip",
                    "ANSWER_3" => "Blue",
-                   "ANSWER_4" => "Dog")
+                   "ANSWER_4" => "Dog",
+                   "KEYWORD" => "One, Two",
+                   "CATEGORY" => "Big, Little")
       end
 
       it { is_expected.to be_valid }
@@ -51,6 +62,13 @@ RSpec.describe Question::DragAndDrop do
                { 'answer' => "Dog", 'correct' => true }
              ])
         )
+      end
+
+      context 'when saved' do
+        before { subject.save }
+
+        its(:keyword_names) { is_expected.to match_array(["One", "Two"]) }
+        its(:category_names) { is_expected.to match_array(["Big", "Little"]) }
       end
     end
   end

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -15,12 +15,21 @@ RSpec.describe Question::Matching do
                  "LEFT_1" => "Animal",
                  "RIGHT_1" => "Cat, Dog",
                  "LEFT_2" => "Plant",
-                 "RIGHT_2" => "Catnip, Dogwood")
+                 "RIGHT_2" => "Catnip, Dogwood",
+                 "KEYWORD" => "One, Two",
+                 "CATEGORY" => "Big, Little")
     end
 
     it { is_expected.to be_valid }
     it { is_expected.not_to be_persisted }
     its(:data) { is_expected.to eq([{ "answer" => "Animal", "correct" => ["Cat", "Dog"] }, { "answer" => "Plant", "correct" => ["Catnip", "Dogwood"] }]) }
+
+    context 'when saved' do
+      before { subject.save }
+
+      its(:keyword_names) { is_expected.to match_array(["One", "Two"]) }
+      its(:category_names) { is_expected.to match_array(["Big", "Little"]) }
+    end
   end
 
   describe 'data serialization' do

--- a/spec/models/question/select_all_that_apply_spec.rb
+++ b/spec/models/question/select_all_that_apply_spec.rb
@@ -15,12 +15,21 @@ RSpec.describe Question::SelectAllThatApply do
                  "ANSWERS" => "1, 3",
                  "ANSWER_1" => "true",
                  "ANSWER_2" => "false",
-                 "ANSWER_3" => "yes")
+                 "ANSWER_3" => "yes",
+                 "KEYWORD" => "One, Two",
+                 "CATEGORY" => "Big, Little")
     end
 
     it { is_expected.to be_valid }
     it { is_expected.not_to be_persisted }
     its(:data) { is_expected.to eq([{ 'answer' => "true", 'correct' => true }, { 'answer' => "false", 'correct' => false }, { 'answer' => "yes", 'correct' => true }]) }
+
+    context 'when saved' do
+      before { subject.save }
+
+      its(:keyword_names) { is_expected.to match_array(["One", "Two"]) }
+      its(:category_names) { is_expected.to match_array(["Big", "Little"]) }
+    end
   end
 
   describe 'data serialization' do

--- a/spec/models/question/traditional_spec.rb
+++ b/spec/models/question/traditional_spec.rb
@@ -14,12 +14,29 @@ RSpec.describe Question::Traditional do
                  "TEXT" => "Which one is true?",
                  "ANSWERS" => "1",
                  "ANSWER_1" => "true",
-                 "ANSWER_2" => "false")
+                 "ANSWER_2" => "false",
+                 "CATEGORIES" => "True/False, Amazing",
+                 "CATEGORY_1" => "Fun Question",
+                 "CATEGORY" => "Hard Question",
+                 "KEYWORDS" => "Red",
+                 "KEYWORD_1" => "Green",
+                 "KEYWORD_2" => "Orange",
+                 "KEYWORD" => "Yellow")
     end
 
     it { is_expected.to be_valid }
     it { is_expected.not_to be_persisted }
     its(:data) { is_expected.to eq([{ "answer" => "true", "correct" => true }, { "answer" => "false", "correct" => false }]) }
+
+    describe 'once saved' do
+      before do
+        subject.save
+        subject.reload
+      end
+
+      its(:keyword_names) { is_expected.to match_array(["Green", "Orange", "Red", "Yellow"]) }
+      its(:category_names) { is_expected.to match_array(["Amazing", "Fun Question", "Hard Question", "True/False"]) }
+    end
   end
 
   describe 'data serialization' do


### PR DESCRIPTION
Prior to this commit, we were not able to assign categories nor keywords
to questions during the import of a CSV.

With this commit, we now can.  See the specs for details on the column
structure.

Also, this includes a minor tweak to how we account for the
`Question.filter` of the given type_name(s); namely handling the Single
Table Inheritance paradigm of ActiveRecord (e.g. child and grand-child
or grand-grand child of a Question class).

Related to:

- https://github.com/scientist-softserv/viva/issues/86