### PR TITLE
♻️ Favor single method instead of method chain

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,11 +6,11 @@ class SearchController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def index
     render inertia: 'Search', props: {
-      keywords: Keyword.all.pluck(:name),
-      categories: Category.all.pluck(:name),
+      keywords: Keyword.names,
+      categories: Category.names,
       types: Question.type_names, # Deprecated Favor :type_names
       type_names: Question.type_names,
-      levels: [1, 2, 3], # hard coding this for now - allows there to be levels in the UI dropdown
+      levels: Level.names,
       selectedKeywords: params[:selected_keywords],
       selectedCategories: params[:selected_categories],
       selectedTypes: params[:selected_types],

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,4 +7,10 @@ class Category < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   self.implicit_order_column = :name
+
+  ##
+  # @return [Array<String>] an alphabetized list of category names.
+  def self.names
+    all.order(name: :asc).pluck(:name)
+  end
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -7,4 +7,10 @@ class Keyword < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   self.implicit_order_column = :name
+
+  ##
+  # @return [Array<String>] an alphabetized list of keyword names.
+  def self.names
+    all.order(name: :asc).pluck(:name)
+  end
 end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+##
+# A placeholder for a future database model of Level.
+module Level
+  ##
+  # @return [Array<String>]
+  def self.names
+    ["1", "2", "3"]
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -122,7 +122,7 @@ class Question < ApplicationRecord
   #
   # @see .filter_as_json
   def keyword_names
-    attributes.fetch(:keyword_names) { keywords.map(&:name) } || []
+    attributes.fetch(:keyword_names) { keywords.names } || []
   end
 
   ##
@@ -134,7 +134,7 @@ class Question < ApplicationRecord
   #
   # @see .filter_as_json
   def category_names
-    attributes.fetch(:category_names) { categories.map(&:name) } || []
+    attributes.fetch(:category_names) { categories.names } || []
   end
 
   ##
@@ -171,7 +171,7 @@ class Question < ApplicationRecord
     # into a class.  ActiveRecord is smart about Single Table Inheritance (STI).  When we coerce
     # use a subclass of Question there's an implict `where` clause that narrows the query to only
     # that subclass and its descendants.
-    questions = Question
+    questions = Question.order(id: :asc)
     types = Array.wrap(type_name).map { |name| type_name_to_class(name).to_s }
     questions = questions.where(type: types) if types.present?
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe SearchController do
                "type" => question.model_name.name, # Deprecated
                "type_label" => question.type_label,
                "level" => question.level,
-               "keyword_names" => question.keywords.map(&:name),
-               "category_names" => question.categories.map(&:name)
+               "keyword_names" => question.keywords.names,
+               "category_names" => question.categories.names
              }
            ])
       )
@@ -53,8 +53,8 @@ RSpec.describe SearchController do
                "type" => question1.model_name.name, # Deprecated
                "type_label" => question1.type_label,
                "level" => question1.level,
-               "keyword_names" => question1.keywords.map(&:name),
-               "category_names" => question1.categories.map(&:name)
+               "keyword_names" => question1.keywords.names,
+               "category_names" => question1.categories.names
              },
              {
                "id" => question2.id,
@@ -64,15 +64,15 @@ RSpec.describe SearchController do
                "type" => question2.model_name.name, # Deprecated
                "type_label" => question2.type_label,
                "level" => question2.level,
-               "keyword_names" => question2.keywords.map(&:name),
-               "category_names" => question2.categories.map(&:name)
+               "keyword_names" => question2.keywords.names,
+               "category_names" => question2.categories.names
              }
            ])
       )
 
       # set the selected keywords, categories, and types to the keywords, categories, and types of question 1
-      selected_keywords = question1.keywords.map(&:name)
-      selected_categories = question1.categories.map(&:name)
+      selected_keywords = question1.keywords.names
+      selected_categories = question1.categories.names
       # selected_types = ['type1', 'type2']
 
       get :index, params: {
@@ -97,8 +97,8 @@ RSpec.describe SearchController do
                "type" => question1.model_name.name, # Deprecated
                "type_label" => question1.type_label,
                "level" => question1.level,
-               "keyword_names" => question1.keywords.map(&:name),
-               "category_names" => question1.categories.map(&:name)
+               "keyword_names" => question1.keywords.names,
+               "category_names" => question1.categories.names
              }
            ])
       )

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
+  describe '.names' do
+    subject { described_class.names }
+    it { is_expected.to be_a(Array) }
+  end
+
   describe 'validations' do
     subject { FactoryBot.build(:category) }
 

--- a/spec/models/keyword_spec.rb
+++ b/spec/models/keyword_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Keyword, type: :model do
+  describe '.names' do
+    subject { described_class.names }
+    it { is_expected.to be_a(Array) }
+  end
+
   describe 'validations' do
     subject { FactoryBot.build(:keyword) }
 

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Level do
+  describe '.names' do
+    subject { described_class.names }
+    it { is_expected.to be_a(Array) }
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe Question, type: :model do
               type_label: question1.type_label,
               level: question1.level,
               data: question1.data,
-              keyword_names: question1.keywords.map(&:name),
-              category_names: question1.categories.map(&:name) }.stringify_keys])
+              keyword_names: question1.keywords.names,
+              category_names: question1.categories.names }.stringify_keys])
       )
     end
     # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
In favoring a single method, we create a canonical source for the questions.

In addition, by creating a class method call `.names` we can leverage that on `Question#keywords#names` and `Question#categories#names` (a helpful feature of Rail's query composer).

In addition, we also expose Level controlled vocabulary

This moves away from hard-coding; in that there's now a method that defines the `Level.names`.  Then in the future, we can swap out how that `Level.names` list is generated.

This builds from the conversation with the client.