### PR TITLE
🎁 Add CSV Header Verification

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -15,6 +15,8 @@ class Question < ApplicationRecord
   class_attribute :type_name, default: "Question", instance_writer: false
   class_attribute :include_in_filterable_type, default: true, instance_writer: false
 
+  class_attribute :require_csv_headers, default: %w[IMPORT_ID TEXT TYPE].freeze
+
   ##
   # @see {Question::StimulusCaseStudy} for aggregation.
   has_one :as_child_question_aggregations, class_name: 'QuestionAggregation', dependent: :destroy, as: :child_question

--- a/app/models/question/expected_column_missing.rb
+++ b/app/models/question/expected_column_missing.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+##
+# When the CSV question we're parsing does not have the {#expected} headers, report an error with
+# that.
+class Question::ExpectedColumnMissing
+  # @param expected [Array<#to_s>]
+  # @param given [Array<#to_s>]
+  def initialize(expected:, given:)
+    @expected = expected
+    @given = given
+    @missing = expected & given
+  end
+
+  def valid?
+    false
+  end
+
+  def errors
+    {
+      expected: @expected,
+      given: @given,
+      missing: @missing
+    }
+  end
+end

--- a/app/models/question/invalid_question.rb
+++ b/app/models/question/invalid_question.rb
@@ -8,6 +8,7 @@ class Question::InvalidQuestion
 
   def initialize(row)
     @row = row
+    valid?
   end
 
   attr_reader :row

--- a/spec/models/question/expected_column_missing_spec.rb
+++ b/spec/models/question/expected_column_missing_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Question::ExpectedColumnMissing do
+  subject(:instance) { described_class.new(expected: ["IMPORT_ID", "TEXT", "TYPE"], given: ["IMPORT_ID", "ANSWER"]) }
+
+  it { is_expected.not_to be_valid }
+
+  describe '#errors' do
+    subject { instance.errors }
+
+    its(:keys) { is_expected.to match_array([:expected, :given, :missing]) }
+  end
+end

--- a/spec/models/question/importer_csv_spec.rb
+++ b/spec/models/question/importer_csv_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe Question::ImporterCsv do
       expect { subject.save }.not_to change(Question::Traditional, :count)
       expect(subject.errors).not_to be_empty
 
-      expect(subject.errors).to be_a(Array)
-      expect(subject.errors.first.keys.sort).to match_array([:errors, :row])
+      expect(subject.errors[:rows]).to be_a(Array)
+
       json = subject.as_json
       expect(json.keys.sort).to eq([:errors, :questions])
-      expect(json[:errors]).to be_present
+      expect(json[:errors]['rows'].first.keys).to match_array(["data", "import_id"])
       expect(json[:questions]).to be_present
     end
   end
@@ -72,11 +72,14 @@ RSpec.describe Question::ImporterCsv do
     end
 
     it 'does not persist the given records' do
-      expect { subject.save }.not_to change(Question::Traditional, :count)
-      expect(subject.errors).not_to be_empty
+      expect { subject.save }.not_to change(Question, :count)
+      expect(subject.errors[:csv]).not_to be_empty
+      expect(subject.errors[:csv].keys).to match_array([:expected, :given, :missing])
 
-      expect(subject.errors).to be_a(Array)
-      expect(subject.errors.first.keys.sort).to match_array([:errors, :row])
+      json = subject.as_json
+      expect(json.keys.sort).to eq([:errors, :questions])
+      expect(json[:errors]['csv'].keys).to match_array(["expected", "given", "missing"])
+      expect(json[:questions]).to be_present
     end
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Question, type: :model do
 
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Question") }
+  its(:require_csv_headers) { is_expected.to eq(%w[IMPORT_ID TEXT TYPE]) }
 
   describe '.descendants' do
     subject { described_class.descendants }


### PR DESCRIPTION
Prior to this commit, we were relying on the rows to check for valid
headers.

With this commit, we check for valid headers on the CSV; when there
aren't valid headers we have one error at the top level.

We also return a singular question to conform to the interface (though
that is up for discussion).