### PR TITLE
🐛 Add transaction around saving all questions

### DIFF
--- a/app/models/question/importer_csv.rb
+++ b/app/models/question/importer_csv.rb
@@ -54,7 +54,9 @@ class Question::ImporterCsv
 
     return false if @errors.present?
 
-    @questions.all?(&:save!)
+    Question.transaction do
+      @questions.all?(&:save!)
+    end
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
Prior to this commit, we do validate the questions.  However, between
validation and writing to the database, things could be "invalid".

By wrapping the saves in a transaction, if one fails, they are all
rolled back.

This is useful because if someone where to upload 20 questions and we
persist 10 then fail on save, then we'd have a CSV that has 20 questions
and 10 of them would've been saved.  Which would mean the end-user would
need to remove those from the CSV and re-upload.

Ultimately, these transactions prevent avoidable duplicated rows.