### PR TITLE
🎁 Add Traditional Question XML format

### DIFF
--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -66,4 +66,65 @@ class Question::Traditional < Question
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/MethodLength
+
+  ##
+  # @!group QTI Exporter
+
+  ##
+  # Necessary for exposing a view like behavior for the {#to_xml} behavior.
+  def question
+    self
+  end
+
+  ##
+  # @return [String] a document
+  # @see https://www.imsglobal.org/spec/qti/v3p0/impl#choice-interaction
+  #
+  # @todo We'll need to consider the structure for multiple
+  def to_xml
+    ERB.new(Rails.root.join("app", "views", "questions", "traditional.qti.xml.erb").read).result(binding)
+  end
+
+  ##
+  # @return [String]
+  def response_cardinality
+    "single"
+  end
+
+  ##
+  # @return [Array<Integer>]
+  def correct_response_identifiers
+    returning_value = []
+    data.each_with_index do |datum, index|
+      returning_value << index if datum.fetch("correct") == true
+    end
+    returning_value
+  end
+
+  ##
+  # @return [Integer]
+  def minimum_choices
+    1
+  end
+
+  ##
+  # @return [Integer]
+  def maximum_choices
+    1
+  end
+
+  ##
+  # @return [Array<Integer, String>]
+  # @yieldparam choice_identifier [Integer]
+  # @yieldparam label [String]
+  def with_each_choice_identifier_and_label
+    returning = []
+    data.each_with_index do |datum, index|
+      returning << [index, datum.fetch("answer")]
+      yield index, datum.fetch("answer") if block_given?
+    end
+    returning
+  end
+  # @!endgroup QTI Exporter
+  ##
 end

--- a/app/views/questions/traditional.qti.xml.erb
+++ b/app/views/questions/traditional.qti.xml.erb
@@ -1,0 +1,22 @@
+<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
+		     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		     xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0
+					 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd"
+		     xml:lang="en-US" identifier="<%= question.id %>" time-dependent="false">
+  <qti-response-declaration identifier="RESPONSE" cardinality="<%= question.response_cardinality %>" base-type="identifier">
+    <qti-correct-response>
+      <% question.correct_response_identifiers.each do |identifier| %>
+        <qti-value><%= identifier %></qti-value>
+      <% end %>
+    </qti-correct-response>
+  </qti-response-declaration>
+  <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float"/>
+  <qti-item-body>
+    <qti-choice-interaction response-identifier="RESPONSE" min-choices="<%= question.minimum_choices %>" max-choices="<%= question.maximum_choices %>">
+      <qti-prompt><%= question.text %></qti-prompt>
+      <% question.with_each_choice_identifier_and_label do |identifier, label| %>
+        <qti-simple-choice identifier="<%= identifier %>"><%= label %></qti-simple-choice>
+      <% end %>
+    </qti-choice-interaction>
+  </qti-item-body>
+</qti-assessment-item>

--- a/spec/models/question/traditional_spec.rb
+++ b/spec/models/question/traditional_spec.rb
@@ -74,4 +74,44 @@ RSpec.describe Question::Traditional do
       end
     end
   end
+
+  its(:maximum_choices) { is_expected.to eq(1) }
+  its(:minimum_choices) { is_expected.to eq(1) }
+  its(:response_cardinality) { is_expected.to eq("single") }
+
+  describe '#to_xml' do
+    let(:question) { FactoryBot.create(:question_traditional) }
+    subject { question.to_xml }
+
+    it 'includes the text prompt' do
+      expect(subject).to include(%(<qti-prompt>#{question.text}</qti-prompt>))
+    end
+
+    it 'does not include the XML pre-amble' do
+      # The pre-amble is to be included when we stitch all of this together.
+      expect(subject).not_to match(%r{\A<\?xml})
+    end
+  end
+
+  describe '#correct_response_identifiers' do
+    subject { FactoryBot.build(:question_traditional, data:).correct_response_identifiers }
+
+    [
+      [[{ answer: "Green", correct: false }, { answer: "Blue", correct: true }], [1]]
+    ].each do |given_data, expected_correct_response_identifiers|
+      context "with #{given_data}" do
+        let(:data) { given_data }
+
+        it { is_expected.to match_array(expected_correct_response_identifiers) }
+      end
+    end
+  end
+
+  describe "#with_each_choice_identifier_and_label" do
+    subject { FactoryBot.build(:question_traditional, data: [{ answer: "Green", correct: false }, { answer: "Blue", correct: true }]) }
+
+    it 'yields the index and answer pair' do
+      expect { |b| subject.with_each_choice_identifier_and_label(&b) }.to yield_successive_args([0, "Green"], [1, "Blue"])
+    end
+  end
 end


### PR DESCRIPTION
This is a "proof of concept" for exporting XML for a
`Question::Traditional` object.  The proof of concept should also work
for the `Question::SelectAllThatApply` (with some modifications).

I went with the absolute minimum setup to get an XML fragment generated.
There would be more as we look to generalize the behavior.

At present, there are no QA tests for exporting these entries.  In part
because only the "Traditional" question has an XML exporter.

Related to:

- https://github.com/scientist-softserv/viva/issues/173