### PR TITLE
🎁 Add XML output for Traditional Question

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -62,6 +62,16 @@ class Question < ApplicationRecord
   end
 
   ##
+  # @return [String]
+  #
+  # @note Yes, by default a question should not have an XML representation...at least until we
+  #       complete the XML mapping.  This is in play to prevent weird breakage of
+  #       {SearchController#index}'s handling of the `xml' format.
+  def to_xml(*)
+    ""
+  end
+
+  ##
   # @see Question::ImporterCsv
   #
   # @param row [Enumerable] likely a row from {CSV.read}.

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -9,99 +9,114 @@ RSpec.describe SearchController do
       sign_in user
     end
 
-    it "returns a 'Search' component with properties of :keywords, :types, :subjects, and :filteredQuestions" do
-      question = FactoryBot.create(:question_matching, :with_keywords, :with_subjects)
-      get :index
-      expect_inertia.to render_component 'Search'
-      expect(inertia.props[:keywords]).to be_a(Array)
-      expect(inertia.props[:subjects]).to be_a(Array)
-      expect(inertia.props[:types]).to be_a(Array)
-      expect(inertia.props[:type_names]).to be_a(Array)
-      expect(inertia.props[:levels]).to be_a(Array)
-      expect(inertia.props[:type_names]).to be_a(Array)
-      expect(inertia.props[:filteredQuestions].as_json).to(
-        eq([
-             {
-               "id" => question.id,
-               "text" => question.text,
-               "type_name" => question.type_name,
-               "data" => question.data,
-               "type" => question.model_name.name, # Deprecated
-               "type_label" => question.type_label,
-               "level" => question.level,
-               "keyword_names" => question.keywords.names,
-               "subject_names" => question.subjects.names
-             }
-           ])
-      )
+    context 'xml format' do
+      it 'uses the search parameters to build the data' do
+        FactoryBot.create(:question_traditional, :with_keywords, :with_subjects)
+        get :index, format: :xml
+
+        expect(response.body).to start_with(described_class::XML_PREAMBLE)
+
+        # Once https://github.com/scientist-softserv/viva/pull/189 is merged, uncomment the
+        # following lines:
+        # question = Question.last
+        # expect(response.body).to include(%(identifier="#{question.id}"))
+      end
     end
 
-    # TODO: account for types and levels
-    it 'makes a request using selected_keywords, selected_subjects, and selected_types, and filters the questions based on these selected values.' do
-      question1 = FactoryBot.create(:question_matching, :with_keywords, :with_subjects)
-      question2 = FactoryBot.create(:question_matching, :with_keywords, :with_subjects)
+    context 'inertia format', inertia: true do
+      it "returns a 'Search' component with properties of :keywords, :types, :subjects, and :filteredQuestions" do
+        question = FactoryBot.create(:question_matching, :with_keywords, :with_subjects)
+        get :index
+        expect_inertia.to render_component 'Search'
+        expect(inertia.props[:keywords]).to be_a(Array)
+        expect(inertia.props[:subjects]).to be_a(Array)
+        expect(inertia.props[:types]).to be_a(Array)
+        expect(inertia.props[:type_names]).to be_a(Array)
+        expect(inertia.props[:levels]).to be_a(Array)
+        expect(inertia.props[:type_names]).to be_a(Array)
+        expect(inertia.props[:exportHrefs]).to match_array([{ href: ".xml", type: "xml" }])
+        expect(inertia.props[:filteredQuestions].as_json).to(
+          eq([
+               {
+                 "id" => question.id,
+                 "text" => question.text,
+                 "type_name" => question.type_name,
+                 "data" => question.data,
+                 "type" => question.model_name.name, # Deprecated
+                 "type_label" => question.type_label,
+                 "level" => question.level,
+                 "keyword_names" => question.keywords.names,
+                 "subject_names" => question.subjects.names
+               }
+             ])
+        )
+      end
 
-      get :index
-      # test that we have both question 1 and 2 to start with
-      expect(inertia.props[:filteredQuestions].as_json).to(
-        eq([
-             {
-               "id" => question1.id,
-               "text" => question1.text,
-               "type_name" => question1.type_name,
-               "data" => question1.data,
-               "type" => question1.model_name.name, # Deprecated
-               "type_label" => question1.type_label,
-               "level" => question1.level,
-               "keyword_names" => question1.keywords.names,
-               "subject_names" => question1.subjects.names
-             },
-             {
-               "id" => question2.id,
-               "text" => question2.text,
-               "type_name" => question2.type_name,
-               "data" => question2.data,
-               "type" => question2.model_name.name, # Deprecated
-               "type_label" => question2.type_label,
-               "level" => question2.level,
-               "keyword_names" => question2.keywords.names,
-               "subject_names" => question2.subjects.names
-             }
-           ])
-      )
+      # TODO: account for types and levels
+      it 'makes a request using selected_keywords, selected_subjects, and selected_types, and filters the questions based on these selected values.' do
+        question1 = FactoryBot.create(:question_matching, :with_keywords, :with_subjects)
+        question2 = FactoryBot.create(:question_matching, :with_keywords, :with_subjects)
 
-      # set the selected keywords, subjects, and types to the keywords, subjects, and types of question 1
-      selected_keywords = question1.keywords.names
-      selected_subjects = question1.subjects.names
-      # selected_types = ['type1', 'type2']
+        get :index
+        # test that we have both question 1 and 2 to start with
+        expect(inertia.props[:filteredQuestions].as_json).to(
+          eq([
+               {
+                 "id" => question1.id,
+                 "text" => question1.text,
+                 "type_name" => question1.type_name,
+                 "data" => question1.data,
+                 "type" => question1.model_name.name, # Deprecated
+                 "type_label" => question1.type_label,
+                 "level" => question1.level,
+                 "keyword_names" => question1.keywords.names,
+                 "subject_names" => question1.subjects.names
+               },
+               {
+                 "id" => question2.id,
+                 "text" => question2.text,
+                 "type_name" => question2.type_name,
+                 "data" => question2.data,
+                 "type" => question2.model_name.name, # Deprecated
+                 "type_label" => question2.type_label,
+                 "level" => question2.level,
+                 "keyword_names" => question2.keywords.names,
+                 "subject_names" => question2.subjects.names
+               }
+             ])
+        )
 
-      get :index, params: {
-        selected_keywords:,
-        selected_subjects:
-        # selected_types: selected_types
-      }
+        # set the selected keywords, subjects, and types to the keywords, subjects, and types of question 1
+        selected_keywords = question1.keywords.names
+        selected_subjects = question1.subjects.names
 
-      # test that the page has the correct params
-      expect(inertia.props[:selectedKeywords]).to eq(selected_keywords)
-      expect(inertia.props[:selectedSubjects]).to eq(selected_subjects)
-      # expect(inertia.props[:selectedTypes]).to eq(selected_types)
+        given_params = { selected_keywords:, selected_subjects: }
+        get :index, params: given_params
 
-      # test that question 2 is filtered out
-      expect(inertia.props[:filteredQuestions].as_json).to(
-        eq([
-             {
-               "id" => question1.id,
-               "text" => question1.text,
-               "type_name" => question1.type_name,
-               "data" => question1.data,
-               "type" => question1.model_name.name, # Deprecated
-               "type_label" => question1.type_label,
-               "level" => question1.level,
-               "keyword_names" => question1.keywords.names,
-               "subject_names" => question1.subjects.names
-             }
-           ])
-      )
+        expect(inertia.props[:exportHrefs]).to match_array([{ href: ".xml?#{given_params.to_query}", type: "xml" }])
+
+        # test that the page has the correct params
+        expect(inertia.props[:selectedKeywords]).to eq(selected_keywords)
+        expect(inertia.props[:selectedSubjects]).to eq(selected_subjects)
+        # expect(inertia.props[:selectedTypes]).to eq(selected_types)
+
+        # test that question 2 is filtered out
+        expect(inertia.props[:filteredQuestions].as_json).to(
+          eq([
+               {
+                 "id" => question1.id,
+                 "text" => question1.text,
+                 "type_name" => question1.type_name,
+                 "data" => question1.data,
+                 "type" => question1.model_name.name, # Deprecated
+                 "type_label" => question1.type_label,
+                 "level" => question1.level,
+                 "keyword_names" => question1.keywords.names,
+                 "subject_names" => question1.subjects.names
+               }
+             ])
+        )
+      end
     end
   end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Question, type: :model do
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Question") }
   its(:required_csv_headers) { is_expected.to eq(%w[IMPORT_ID TEXT TYPE]) }
+  its(:to_xml) { is_expected.to eq("") }
 
   describe '.descendants' do
     subject { described_class.descendants }


### PR DESCRIPTION
This commit involves three significant elements:

1. A refactor of the specs to test the `exportHrefs`
2. Restructuring the specs to have a "by format" consideration; as the inertia response behaves differently from other respond to (at least I think)
3. Introduce the logic for exporting an XML document.

Because I'm introducing the ability to export a filtered value, but only have the export for the Traditional question, I also introduced `Question#to_xml` to ensure we can test the downloads without having all of the XML mappings complete.

Related to:

- https://github.com/scientist-softserv/viva/issues/168
- https://github.com/scientist-softserv/viva/issues/169
- https://github.com/scientist-softserv/viva/issues/170
- https://github.com/scientist-softserv/viva/issues/171
- https://github.com/scientist-softserv/viva/issues/172
- https://github.com/scientist-softserv/viva/issues/173