### PR TITLE
🎁 Improve SelectAllThatApply validation messages for import

### DIFF
--- a/spec/models/question/select_all_that_apply_spec.rb
+++ b/spec/models/question/select_all_that_apply_spec.rb
@@ -7,6 +7,26 @@ RSpec.describe Question::SelectAllThatApply do
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Select All That Apply") }
 
+  describe "ImportCsvRow inner_class" do
+    describe 'save!' do
+      subject { described_class::ImportCsvRow.new(row: data, question_type: described_class) }
+
+      context 'when inner_class is invalid' do
+        let(:data) do
+          CsvRow.new("ANSWERS" => "2,4,6",
+                     "ANSWER_1" => "Hello World!",
+                     "ANSWER_3" => "Something",
+                     "ANSWER_5" => "Else")
+        end
+
+        it "will not call the underlying question's save!" do
+          expect(subject.question).not_to receive(:save!)
+          expect { subject.save! }.to raise_error(ActiveRecord::RecordInvalid, /ANSWERS column indicates that ANSWER_2, ANSWER_4, ANSWER_6/)
+        end
+      end
+    end
+  end
+
   describe '.build_row' do
     subject { described_class.build_row(row) }
     let(:row) do


### PR DESCRIPTION
Prior to this commit, the validation error messages sent to the person
uploading a SelectAllThatApply question talked about hashes and arrays;
something that was not part of their CSV.

With this commit, we're trying to provide guidance as to the CSV
validation by referencing named columns.

Related to:

- https://github.com/scientist-softserv/viva/pull/191
- https://github.com/scientist-softserv/viva/issues/181