### PR TITLE
🎁 Improve Matching validation messages for import

### DIFF
--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -7,32 +7,60 @@
 class Question::Matching < Question
   self.type_name = "Matching"
 
-  # rubocop:disable Metrics/MethodLength
-  def self.build_row(row)
-    text = row['TEXT']
-    level = row['LEVEL']
-    subject_names = extract_subject_names_from(row)
-    keyword_names = extract_keyword_names_from(row)
+  ##
+  # Represents the mapping process of a CSV Row to the underlying {Question::Matching}.
+  #
+  # The primary purpose of this class is to convey meaningful error messages for invalid CSV
+  # structures.
+  #
+  # @see {#validate_well_formed_row}
+  class ImportCsvRow < Question::ImportCsvRow
+    ##
+    # @see #validate_well_formed_row
+    #
+    # rubocop:disable Metrics/MethodLength
+    def extract_answers_and_data_from(row)
+      # These are reused in #validate_well_formed_row
+      @lefts = []
+      @rights = []
+      # Ensure that we have all of the candidate indices (the left and right side)
+      row.headers.each do |header|
+        next if header.blank?
 
-    # Ensure that we have all of the candidate indices (the left and right side)
-    indices = row.headers.each_with_object([]) do |header, array|
-      next if header.blank?
-      next unless header.start_with?("LEFT_", "RIGHT_")
-      array << header.split(/_+/).last.to_i
-    end.uniq.sort
+        if header.start_with?("LEFT_")
+          @lefts << header.split(/_+/).last.to_i
+        elsif header.start_with?("RIGHT_")
+          @rights << header.split(/_+/).last.to_i
+        end
+      end
 
-    data = indices.each_with_object([]) do |index, array|
-      # It is okay that these will possibly be nil; because our downstream validation will catch
-      # them.
-      answer = row["LEFT_#{index}"]
-      correct = row["RIGHT_#{index}"]&.split(/\s*,\s*/)
-      next if answer.blank? && correct.blank?
-      array << { answer:, correct: }
+      indices = (@lefts + @rights).uniq.sort
+
+      @data = indices.each_with_object([]) do |index, array|
+        # It is okay that these will possibly be nil; because our downstream validation will catch
+        # them.
+        answer = row["LEFT_#{index}"]
+        correct = row["RIGHT_#{index}"]&.split(/\s*,\s*/)
+        next if answer.blank? && correct.blank?
+        array << { "answer" => answer, "correct" => correct }
+      end
     end
+    # rubocop:enable Metrics/MethodLength
 
-    new(text:, data:, subject_names:, keyword_names:, level:)
+    def validate_well_formed_row
+      return unless @lefts.sort != @rights.sort
+      message = "mismatch of LEFT and RIGHT columns."
+      left_has = @lefts - @rights
+      message += " Have LEFT_#{left_has.join(', LEFT_')} columns without corresponding RIGHT_#{left_has.join(', RIGHT_')} columns." if left_has.any?
+      right_has = @rights - @lefts
+      message += " Have RIGHT_#{right_has.join(', RIGHT_')} columns without corresponding LEFT_#{right_has.join(', LEFT_')} columns." if right_has.any?
+      errors.add(:data, message)
+    end
   end
-  # rubocop:enable Metrics/MethodLength
+
+  def self.build_row(row)
+    ImportCsvRow.new(question_type: self, row:)
+  end
 
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -9,30 +9,56 @@ RSpec.describe Question::Matching do
 
   describe '.build_row' do
     subject { described_class.build_row(row) }
-    let(:row) do
-      CsvRow.new("TYPE" => "Matching",
-                 "TEXT" => "Matching the proper pairings:",
-                 "LEVEL" => Level.names.first,
-                 "LEFT_1" => "Animal",
-                 "RIGHT_1" => "Cat, Dog",
-                 "LEFT_2" => "Plant",
-                 "RIGHT_2" => "Catnip, Dogwood",
-                 "LEFT_3" => "",
-                 "RIGHT_3" => "",
-                 "KEYWORD" => "One, Two",
-                 "SUBJECT" => "Big, Little")
+    context 'with invalid data due to mismatched columns' do
+      let(:row) do
+        CsvRow.new("TYPE" => "Matching",
+                   "TEXT" => "Matching the proper pairings:",
+                   "LEVEL" => Level.names.first,
+                   "LEFT_1" => "Animal",
+                   "LEFT_3" => "Mineral",
+                   "RIGHT_2" => "Cat, Dog",
+                   "RIGHT_4" => "Weird",
+                   "LEFT_5" => "Yup",
+                   "RIGHT_5" => "It Matches",
+                   "KEYWORD" => "One, Two",
+                   "SUBJECT" => "Big, Little")
+      end
+      it { is_expected.not_to be_valid }
+      it { is_expected.not_to be_persisted }
+      it "will not call the underlying question's save!" do
+        expect(subject.question).not_to receive(:save!)
+        # I could have one regular expression for this, but figure splitting it apart helps show with clarity.
+        expect { subject.save! }.to raise_error(/Have LEFT_1, LEFT_3 columns without corresponding RIGHT_1, RIGHT_3 columns/)
+        expect { subject.save! }.to raise_error(/Have RIGHT_2, RIGHT_4 columns without corresponding LEFT_2, LEFT_4 columns/)
+      end
     end
 
-    it { is_expected.to be_valid }
-    it { is_expected.not_to be_persisted }
-    its(:data) { is_expected.to eq([{ "answer" => "Animal", "correct" => ["Cat", "Dog"] }, { "answer" => "Plant", "correct" => ["Catnip", "Dogwood"] }]) }
+    context 'with valid data' do
+      let(:row) do
+        CsvRow.new("TYPE" => "Matching",
+                   "TEXT" => "Matching the proper pairings:",
+                   "LEVEL" => Level.names.first,
+                   "LEFT_1" => "Animal",
+                   "RIGHT_1" => "Cat, Dog",
+                   "LEFT_2" => "Plant",
+                   "RIGHT_2" => "Catnip, Dogwood",
+                   "LEFT_3" => "",
+                   "RIGHT_3" => "",
+                   "KEYWORD" => "One, Two",
+                   "SUBJECT" => "Big, Little")
+      end
 
-    context 'when saved' do
-      before { subject.save }
+      it { is_expected.to be_valid }
+      it { is_expected.not_to be_persisted }
+      its(:data) { is_expected.to eq([{ "answer" => "Animal", "correct" => ["Cat", "Dog"] }, { "answer" => "Plant", "correct" => ["Catnip", "Dogwood"] }]) }
 
-      its(:keyword_names) { is_expected.to match_array(["One", "Two"]) }
-      its(:subject_names) { is_expected.to match_array(["Big", "Little"]) }
-      its(:level) { is_expected.to eq(Level.names.first) }
+      context 'when saved' do
+        before { subject.save }
+
+        its(:keyword_names) { is_expected.to match_array(["One", "Two"]) }
+        its(:subject_names) { is_expected.to match_array(["Big", "Little"]) }
+        its(:level) { is_expected.to eq(Level.names.first) }
+      end
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the validation error messages sent to the person
uploading a Matching question talked about hashes and arrays;
something that was not part of their CSV.

With this commit, we're trying to provide guidance as to the CSV
validation by referencing named columns.

Related to:

- https://github.com/scientist-softserv/viva/issues/183