### PR TITLE
⚙️ Update Node.js installation due to deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 FROM ruby:3.1.4 as viva-base
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
-  apt-get update -qq &&\
-  apt-get install -y \
+
+# Install dependencies for the NodeSource repo and Node.js
+RUN apt-get update -qq && \
+    apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+# Add the NodeSource repo for Node 18
+ENV NODE_MAJOR=18
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+# Install Node.js and other dependencies
+RUN apt-get update -qq && \
+    apt-get install -y \
     nodejs \
     postgresql-client \
     vim-tiny && \
-  npm install -g yarn
+    npm install -g yarn
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
The Node.js installation script setup_18.x is deprecated and no longer functional. This commit will update the Dockerfile to use the new installation method from the NodeSource distributions GitHub repo README.

Changes include:
- Removing the call to the deprecated setup script.
- Adding commands to import the NodeSource GPG key directly.
- Creating a new .list file for the NodeSource repository.
- Installing Node.js from the newly added NodeSource repo.