### PR TITLE
♻️ Introduce :questions to build_row method sig

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ AllCops:
 
 Rails/HasAndBelongsToMany:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false

--- a/app/models/question/bow_tie.rb
+++ b/app/models/question/bow_tie.rb
@@ -134,10 +134,6 @@ class Question::BowTie < Question
     # rubocop:enable Metrics/PerceivedComplexity
   end
 
-  def self.build_row(row)
-    ImportCsvRow.new(question_type: self, row:)
-  end
-
   ##
   # Verify that the resulting data attribute is an array with each element being an array of two
   # strings.

--- a/app/models/question/drag_and_drop.rb
+++ b/app/models/question/drag_and_drop.rb
@@ -85,10 +85,6 @@ class Question::DragAndDrop < Question
     # rubocop:enable Metrics/CyclomaticComplexity
   end
 
-  def self.build_row(row)
-    ImportCsvRow.new(question_type: self, row:)
-  end
-
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.
   serialize :data, JSON

--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -58,10 +58,6 @@ class Question::Matching < Question
     end
   end
 
-  def self.build_row(row)
-    ImportCsvRow.new(question_type: self, row:)
-  end
-
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.
   serialize :data, JSON

--- a/app/models/question/scenario.rb
+++ b/app/models/question/scenario.rb
@@ -9,7 +9,7 @@ class Question::Scenario < Question
   self.type_name = "Scenario"
   self.include_in_filterable_type = false
 
-  def self.build_row(row)
+  def self.build_row(row:, **)
     # TODO: This is naive in that it assumes a full blown object.  It's also highlighting that we're
     # likely going to want a Csv Importer class; one that can handle the validation then reporting
     # errors or persisting objects.

--- a/app/models/question/select_all_that_apply.rb
+++ b/app/models/question/select_all_that_apply.rb
@@ -44,10 +44,6 @@ class Question::SelectAllThatApply < Question
     end
   end
 
-  def self.build_row(row)
-    ImportCsvRow.new(question_type: self, row:)
-  end
-
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.
   serialize :data, JSON

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -38,10 +38,6 @@ class Question::Traditional < Question
     end
   end
 
-  def self.build_row(row)
-    ImportCsvRow.new(question_type: self, row:)
-  end
-
   # NOTE: We're not storing this in a JSONB data type, but instead favoring a text field.  The need
   # for the data to be used in the application, beyond export of data, is minimal.
   #

--- a/spec/models/question/bow_tie_spec.rb
+++ b/spec/models/question/bow_tie_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Question::BowTie do
   its(:type_name) { is_expected.to eq("Bow Tie") }
 
   describe '.build_row' do
-    subject { described_class.build_row(data) }
+    subject { described_class.build_row(row: data, questions: {}) }
 
     let(:base_line_data) do
       {

--- a/spec/models/question/drag_and_drop_spec.rb
+++ b/spec/models/question/drag_and_drop_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Question::DragAndDrop do
   its(:type_name) { is_expected.to eq("Drag and Drop") }
 
   describe '.build_row' do
-    subject { described_class.build_row(row) }
+    subject { described_class.build_row(row:, questions: {}) }
 
     context 'when given invalid slotted data' do
       let(:row) do

--- a/spec/models/question/importer_csv_spec.rb
+++ b/spec/models/question/importer_csv_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Question::ImporterCsv do
 
     it 'does not persist the records and report errors' do
       expect { subject.save }.not_to change(Question::Traditional, :count)
-      expect(subject.errors).to eq({ rows: [{ data: "duplicate IMPORT_ID 1 found on multiple rows", import_id: "1" }] })
+      expect(subject.errors).to eq({ rows: [{ data: ["duplicate IMPORT_ID 1 found on multiple rows"], import_id: "1" }] })
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe Question::ImporterCsv do
       json = subject.as_json
       expect(json.keys.sort).to eq([:errors, :questions])
       expect(json[:errors]['rows'].first.keys).to match_array(["data", "import_id"])
-      expect(json[:questions]).to be_present
+      expect(json[:questions]).not_to be_present
     end
   end
 

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Question::Matching do
   its(:type_name) { is_expected.to eq("Matching") }
 
   describe '.build_row' do
-    subject { described_class.build_row(row) }
+    subject { described_class.build_row(row:, questions: {}) }
     context 'with invalid data due to mismatched columns' do
       let(:row) do
         CsvRow.new("TYPE" => "Matching",

--- a/spec/models/question/scenario_spec.rb
+++ b/spec/models/question/scenario_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Question::Scenario do
   its(:data) { is_expected.to be_nil }
 
   describe '.build_row' do
-    subject { described_class.build_row(row) }
+    subject { described_class.build_row(row:, questions: {}) }
     let(:row) do
       CsvRow.new("TYPE" => "Scenario",
                  "TEXT" => "Something Something Scenario",

--- a/spec/models/question/select_all_that_apply_spec.rb
+++ b/spec/models/question/select_all_that_apply_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::SelectAllThatApply do
 
   describe "ImportCsvRow inner_class" do
     describe 'save!' do
-      subject { described_class::ImportCsvRow.new(row: data, question_type: described_class) }
+      subject { described_class::ImportCsvRow.new(row: data, question_type: described_class, questions: {}) }
 
       context 'when inner_class is invalid' do
         let(:data) do
@@ -28,7 +28,7 @@ RSpec.describe Question::SelectAllThatApply do
   end
 
   describe '.build_row' do
-    subject { described_class.build_row(row) }
+    subject { described_class.build_row(row:, questions: {}) }
     let(:row) do
       CsvRow.new("TYPE" => "AllThatApply",
                  "TEXT" => "Which one is affirmative?",

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Question::StimulusCaseStudy do
   it { is_expected.to have_many(:child_questions) }
 
   describe 'factories' do
-    xit "generates child questions" do
+    it "generates child questions" do
       expect do
         expect do
           FactoryBot.create(:question_stimulus_case_study)
@@ -23,7 +23,7 @@ RSpec.describe Question::StimulusCaseStudy do
     end
   end
 
-  xdescribe '#data' do
+  describe '#data' do
     subject { FactoryBot.create(:question_stimulus_case_study).data }
     it "is comprised of the child_question's metadata" do
       expect(subject).to be_a(Array)

--- a/spec/models/question/traditional_spec.rb
+++ b/spec/models/question/traditional_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::Traditional do
 
   describe "ImportCsvRow inner_class" do
     describe 'save!' do
-      subject { described_class::ImportCsvRow.new(row: data, question_type: described_class) }
+      subject { described_class::ImportCsvRow.new(row: data, question_type: described_class, questions: {}) }
 
       context 'when inner_class is invalid' do
         let(:data) do
@@ -25,7 +25,7 @@ RSpec.describe Question::Traditional do
   end
 
   describe '.build_row' do
-    subject { described_class.build_row(data) }
+    subject { described_class.build_row(row: data, questions: {}) }
     let(:data) do
       CsvRow.new("IMPORT_ID" => "123456",
                  "TYPE" => "Traditional",

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Question, type: :model do
   end
 
   describe '.build_from_csv_row' do
-    subject { described_class.build_from_csv_row(row) }
+    subject { described_class.build_from_csv_row(row:, questions: {}) }
 
     context 'when no row TYPE is provided' do
       let(:row) { CsvRow.new('IMPORT_ID' => '1') }
@@ -43,12 +43,6 @@ RSpec.describe Question, type: :model do
 
       it { is_expected.to be_a(Question::InvalidType) }
       it { is_expected.not_to be_valid }
-    end
-  end
-
-  describe '.build_row' do
-    it 'should be implemented by subclasses' do
-      expect { described_class.build_row }.to raise_error(NotImplementedError)
     end
   end
 
@@ -137,7 +131,6 @@ RSpec.describe Question, type: :model do
     end
 
     # rubocop:disable RSpec/ExampleLength
-    # rubocop:disable RSpec/MultipleExpectations
     it 'filters by keyword' do
       # Why this one large test instead of many smaller tests?  Because the setup cost for the state
       # of the data is noticable.  In other words, by running multiple tests with one setup
@@ -196,6 +189,16 @@ RSpec.describe Question, type: :model do
       expect(described_class.filter(type_name: question1.type_name, keywords: [keyword2.name])).to eq([])
     end
     # rubocop:enable RSpec/ExampleLength
-    # rubocop:enable RSpec/MultipleExpectations
+  end
+
+  describe '#errors' do
+    subject { described_class.new }
+
+    # This spec verifies the interface of the Question#errors#to_hash
+    it 'is a Hash<Symbol,Array<String>> data structure' do
+      expect(subject).not_to be_valid
+
+      expect(subject.errors.to_hash[:text]).to be_a(Array)
+    end
   end
 end


### PR DESCRIPTION
This refactor is building towards implementing
`Question::StimulusCaseStudy` functionality (see #197).

Key is that we need to pass along the existing questions when we build a
record from a row.  The reason is that a `Question::StimulusCaseStudy`
is comprised of other questions.  And when we encounter that other
question we need to be able to look at the existing questions and build
the association.

This refactor moved from a single positional parameter to named
parameters, so we don't need to worry about the order of those
parameters.

The refactor also re-arranges the logic of row validity; namely we now
check both if the IMPORT_ID is a duplicate and if the `row` is invalid.

The last part is to move away from each subclass declaring a
`self.build_row`; that is an artificat of when the `.build_row` method
had notably unique logic.  Now that build is encapsulated in the
CsvImportRow.

Related to:

- https://github.com/scientist-softserv/viva/issues/197