### PR TITLE
🎁 Add StimulusCaseStudy Scenario Handling

### DIFF
--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -16,6 +16,12 @@ class Question::StimulusCaseStudy < Question
            class_name: "Question",
            source_type: "Question"
 
+  class ImportCsvRow < Question::ImportCsvRow
+    def extract_answers_and_data_from(*); end
+
+    def validate_well_formed_row; end
+  end
+
   ##
   # @note Due to the implementation of {Question.filter_as_json} and {Question.filter}, this is not
   #       performant.  That is it will result in potentially many sub-queries.  One solution would

--- a/spec/models/question/importer_csv_spec.rb
+++ b/spec/models/question/importer_csv_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe Question::ImporterCsv do
     end
   end
 
+  context 'with stimulus case study and child scenario' do
+    let(:text) do
+      "IMPORT_ID,TYPE,TEXT,PART_OF\n" \
+      "1,Stimulus Case Study,Valid study,,\n" \
+      "2,Scenario,Valid scenario,1,\n"
+    end
+
+    it 'creates a case study and child scenario' do
+      expect do
+        expect do
+          subject.save
+        end.to change(Question::StimulusCaseStudy, :count).by(1)
+      end.to change(Question::Scenario, :count).by(1)
+
+      scs = Question::StimulusCaseStudy.last
+      scenario = Question::Scenario.last
+      expect(scs.child_questions).to match_array(scenario)
+    end
+  end
+
   context 'with duplicate IMPORT_ID' do
     let(:text) do
       "IMPORT_ID,TYPE,TEXT,ANSWERS,ANSWER_1,ANSWER_2,ANSWER_3\n" \

--- a/spec/models/question/scenario_spec.rb
+++ b/spec/models/question/scenario_spec.rb
@@ -13,14 +13,15 @@ RSpec.describe Question::Scenario do
   its(:data) { is_expected.to be_nil }
 
   describe '.build_row' do
-    subject { described_class.build_row(row:, questions: {}) }
+    subject { described_class.build_row(row:, questions:) }
     let(:row) do
       CsvRow.new("TYPE" => "Scenario",
                  "TEXT" => "Something Something Scenario",
-                 "PART_OF" => case_study)
+                 "PART_OF" => 1)
     end
 
     context 'when provided an existing PART_OF' do
+      let(:questions) { { 1 => case_study } }
       let(:case_study) { FactoryBot.build(:question_stimulus_case_study_without_children) }
 
       it { is_expected.to be_valid }
@@ -28,6 +29,7 @@ RSpec.describe Question::Scenario do
     end
 
     context 'when not provided a PART_OF' do
+      let(:questions) { {} }
       let(:case_study) { nil }
       it { is_expected.not_to be_valid }
       it { is_expected.not_to be_persisted }


### PR DESCRIPTION
This commit works with the easiest logic for sub-questions of a
`Question::StimulusCaseStudy`; namely the `Question::Scenario`.  The
`Question::Scenario` does not exist as a stand-alone question.
So this begins the process of building a case study.

Next up is to incorporate the case study for other sub-types.

Related to:

- https://github.com/scientist-softserv/viva/issues/197