### PR TITLE
🎁 Traditional Question may now be PART_OF

### DIFF
--- a/app/models/question/scenario.rb
+++ b/app/models/question/scenario.rb
@@ -7,31 +7,15 @@
 class Question::Scenario < Question
   self.type_label = "Scenario"
   self.type_name = "Scenario"
-  self.include_in_filterable_type = false
+  self.included_in_filterable_type = false
 
   class ImportCsvRow < Question::ImportCsvRow
     def extract_answers_and_data_from(_row)
       true
     end
 
-    def question
-      return @question if defined?(@question)
-
-      parent_question = questions[row['PART_OF']]&.question
-
-      @question = question_type.new(text: row['TEXT'], parent_question:)
-
-      parent_question.child_questions << @question if parent_question
-
-      @question
-    end
-
     def validate_well_formed_row
-      if row['PART_OF']
-        errors.add(:data, "expected PART_OF value to be an IMPORT_ID of another row in the CSV.") unless questions[row['PART_OF']]
-      else
-        errors.add(:data, "expected PART_OF column for CSV row.")
-      end
+      errors.add(:data, "expected PART_OF column for CSV row.") unless row['PART_OF']
     end
   end
 

--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -5,6 +5,7 @@
 class Question::StimulusCaseStudy < Question
   self.type_label = "Case Study"
   self.type_name = "Stimulus Case Study"
+  self.has_parts = true
 
   has_many :as_parent_question_aggregations,
            class_name: "QuestionAggregation",

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -28,6 +28,10 @@ class Question::Traditional < Question
     end
 
     def validate_well_formed_row
+      if row['PART_OF']
+        errors.add(:data, "expected PART_OF value to be an IMPORT_ID of another row in the CSV.") unless questions[row['PART_OF']]
+      end
+
       if answers.size == 1
         if answer_columns.exclude?("ANSWER_#{answers.first}")
           errors.add(:data, "ANSWERS column indicates that ANSWER_#{answers.first} column should be the correct answer, but there is no ANSWER_#{answers.first}")

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -64,7 +64,7 @@ FactoryBot.define do
 
     factory :question_stimulus_case_study, class: Question::StimulusCaseStudy, parent: :question_stimulus_case_study_without_children do
       after(:build) do |question, _context|
-        child_question_classes = Question.descendants.select(&:include_in_filterable_type?) - [question.class]
+        child_question_classes = Question.descendants.select(&:included_in_filterable_type?) - [question.class]
 
         (0..5).map do |i|
           # Injecting some scenarios into the questions.

--- a/spec/models/question/scenario_spec.rb
+++ b/spec/models/question/scenario_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Question::Scenario do
-  it_behaves_like "a Question", test_type_name_to_class: false, include_in_filterable_type: false
+  it_behaves_like "a Question", test_type_name_to_class: false, included_in_filterable_type: false
   its(:type_label) { is_expected.to eq("Scenario") }
   its(:type_name) { is_expected.to eq("Scenario") }
 

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Question::StimulusCaseStudy do
-  it_behaves_like "a Question"
+  it_behaves_like "a Question", has_parts: true
   its(:type_label) { is_expected.to eq("Case Study") }
   its(:type_name) { is_expected.to eq("Stimulus Case Study") }
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Question, type: :model do
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Question") }
   its(:required_csv_headers) { is_expected.to eq(%w[IMPORT_ID TEXT TYPE]) }
+  it { is_expected.not_to have_parts }
 
   describe '.descendants' do
     subject { described_class.descendants }

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a Question' do |valid: true, test_type_name_to_class: true, include_in_filterable_type: true|
+RSpec.shared_examples 'a Question' do |valid: true, test_type_name_to_class: true, included_in_filterable_type: true, has_parts: false|
   it { is_expected.to respond_to(:keyword_names) }
   it { is_expected.to respond_to(:subject_names) }
   its(:keyword_names) { is_expected.to be_a(Array) }
   its(:subject_names) { is_expected.to be_a(Array) }
   its(:type_label) { is_expected.to be_a(String) }
   its(:type_name) { is_expected.to be_a(String) }
-  its(:include_in_filterable_type) { is_expected.to eq(include_in_filterable_type) }
+  its(:included_in_filterable_type?) { is_expected.to eq(included_in_filterable_type) }
+  its(:has_parts?) { is_expected.to eq(has_parts) }
 
   if test_type_name_to_class
     describe '.type_name_to_class' do


### PR DESCRIPTION
This commit includes:

- some documentation
- alphabetizing of class attribute declarations
- renaming a method for better "reading"/verb tense
- moving assignment of a parent question up from the
  `Question::Scenario::ImportCsvRow` to its ancestor; thus allowing all
  question types to benefit from this logic
- extracting general validation logic for "when someone declares a
  "PART_OF" in the CSV row.

It is possible, though untested that all `Question` types can be
"PART_OF".

Related to:

- https://github.com/scientist-softserv/viva/issues/197