### PR TITLE
🎁 Validate StimulusCaseStudy not part of another question

### DIFF
--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -20,7 +20,11 @@ class Question::StimulusCaseStudy < Question
   class ImportCsvRow < Question::ImportCsvRow
     def extract_answers_and_data_from(*); end
 
-    def validate_well_formed_row; end
+    def validate_well_formed_row
+      return unless row['PART_OF']
+
+      errors.add(:data, "A #{question.type_name} cannot be part of another question.")
+    end
   end
 
   ##

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -10,6 +10,31 @@ RSpec.describe Question::StimulusCaseStudy do
   it { is_expected.to have_many(:as_parent_question_aggregations) }
   it { is_expected.to have_many(:child_questions) }
 
+  describe '.build_row' do
+    subject { described_class.build_row(row:, questions: { 1 => FactoryBot.build(:question_stimulus_case_study) }) }
+
+    context 'when PART_OF another question' do
+      let(:row) do
+        CsvRow.new("TITLE" => "Title",
+                   "PART_OF" => 1,
+                   "IMPORT_ID" => 2,
+                   "TEXT" => "Hello World")
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when PART_OF another question' do
+      let(:row) do
+        CsvRow.new("TITLE" => "Title",
+                   "IMPORT_ID" => 2,
+                   "TEXT" => "Hello World")
+      end
+
+      it { is_expected.to be_valid }
+    end
+  end
+
   describe 'factories' do
     it "generates child questions" do
       expect do


### PR DESCRIPTION
Prior to this commit, we were not actively guarding against a user
entering a Case Study as part of another question.

With this commit we're guarding against that input.

Related to:

- https://github.com/scientist-softserv/viva/issues/197
- https://github.com/scientist-softserv/viva/issues/180