### PR TITLE
☑️ Verify each question can be a child of Stimulus

### DIFF
--- a/public/valid_matching_question.csv
+++ b/public/valid_matching_question.csv
@@ -1,2 +1,2 @@
-IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
+IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2,
 67890,Matching,Identify the selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs).,"SSRI, SNRI",Nursing,,Selective Serotonin Reuptake Inhibitors,Serotonin-norepinephrine reuptake Inhibitors,"Citalopram, Escitalopram, Paroxetine, Fluoxetine","Desvenlafaxine, Levomilnacipran, Duloxetine, Venlafaxine"

--- a/spec/models/question/bow_tie_spec.rb
+++ b/spec/models/question/bow_tie_spec.rb
@@ -21,11 +21,16 @@ RSpec.describe Question::BowTie do
     end
 
     [
-      [{ "CENTER_LABEL" => "Center", "CENTER_1" => "...hello..." }, /missing LEFT_LABEL, RIGHT_LABEL/],
-      [{ "CENTER_LABEL" => "C", "RIGHT_LABEL" => "R", "LEFT_LABEL" => "L" }, /missing CENTER_ANSWERS, LEFT_ANSWERS, RIGHT_ANSWERS/],
-      [{ "CENTER_LABEL" => "C", "RIGHT_LABEL" => "R", "RIGHT_ANSWERS" => '1', "LEFT_LABEL" => "L" }, /missing CENTER_ANSWERS, LEFT_ANSWERS/],
+      [{ "CENTER_LABEL" => "Center", "CENTER_1" => "...hello..." },
+       /missing LEFT_LABEL, RIGHT_LABEL/],
+      [{ "CENTER_LABEL" => "C", "RIGHT_LABEL" => "R", "LEFT_LABEL" => "L" },
+       /missing CENTER_ANSWERS, LEFT_ANSWERS, RIGHT_ANSWERS/],
+      [{ "CENTER_LABEL" => "C", "RIGHT_LABEL" => "R", "RIGHT_ANSWERS" => '1', "LEFT_LABEL" => "L" },
+       /missing CENTER_ANSWERS, LEFT_ANSWERS/],
+      [{ "RIGHT_LABEL" => "R", "RIGHT_ANSWERS" => 'R,r' },
+       /RIGHT_ANSWERS should reference only RIGHT_\<INTEGER\> columns; instead got RIGHT_R, RIGHT_r/],
       [{ "CENTER_LABEL" => "C", "CENTER_ANSWERS" => '1', "RIGHT_LABEL" => "R", "RIGHT_ANSWERS" => '1', "LEFT_LABEL" => "L", 'LEFT_ANSWERS' => '1', 'LEFT_1' => 'Hello' },
-       /Expected columns CENTER_1 but was missing CENTER_1/]
+       /expected columns CENTER_1 but was missing CENTER_1/]
     ].each do |given_data, message|
       context "with #{given_data.inspect}" do
         let(:data) { CsvRow.new(base_line_data.merge(given_data)) }


### PR DESCRIPTION
This commit includes minor refactors as well as verification that we can
create Stimulus sub-questions based on existing question models.

The refactors are to move towards consistent use of
`errors.add(:data,"msg")` and to favor lower case error messages;
because of how they render/show.

Related to:

- https://github.com/scientist-softserv/viva/issues/197
- https://github.com/scientist-softserv/viva/issues/182