### PR TITLE
🧹 Improve code-coverage

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -64,8 +64,4 @@ class SearchController < ApplicationController
       levels: params[:selected_levels]
     }
   end
-
-  def search_params
-    params.permit(:selected_keywords, :selected_subjects, :selected_types, :selected_levels)
-  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -143,9 +143,11 @@ class Question < ApplicationRecord
     validate :validate_well_formed_row
     validate :valid_question_for_part_of
 
+    # :nocov:
     def validate_well_formed_row
       raise NotImplementedError, "#{self}##{__method__}"
     end
+    # :nocov:
 
     def valid_question_for_part_of
       return unless row['PART_OF']
@@ -157,9 +159,11 @@ class Question < ApplicationRecord
       end
     end
 
+    # :nocov:
     def extract_answers_and_data_from(row)
       raise NotImplementedError, "#{self}##{__method__}"
     end
+    # :nocov:
 
     ##
     # What's happening here?  Given that we have layers of validation; it would be nice to rely on

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -37,7 +37,7 @@ class Question::Traditional < Question
           errors.add(:data, "ANSWERS column indicates that ANSWER_#{answers.first} column should be the correct answer, but there is no ANSWER_#{answers.first}")
         end
       else
-        errors.add(:data, "Expected ANSWERS cell to have one correct answer.  The following columns are marked as correct answers: #{answers.map { |a| "ANSWER_#{a}" }.join(',')}")
+        errors.add(:data, "expected ANSWERS cell to have one correct answer.  The following columns are marked as correct answers: #{answers.map { |a| "ANSWER_#{a}" }.join(',')}")
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,9 +22,11 @@ module Viva
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    # :nocov:
     config.generators.after_generate do |files|
       parsable_files = files.filter { |file| file.end_with?('.rb') }
       system("bundle exec rubocop -a --fail-level=E #{parsable_files.shelljoin}", exception: true)
     end
+    # :nocov:
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,11 +30,13 @@ require 'inertia_rails/rspec'
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
+# :nocov:
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e
   abort(e.to_s.strip)
 end
+# :nocov:
 
 require 'database_cleaner/active_record'
 


### PR DESCRIPTION
In reviewing the code coverage, there were places that would likely
never be hit but are important for defined interfaces or for catching
unlikely conditions or for initial application code.

There was also a vestigal method (e.g. `#search_params`) that could be
removed.

Further, I refactored a test to bring it inline with others and added a
test condition that would call previously untested code.

The result of this change is:

- moving code coverage from 98.99% to 99.45%
- testing an untested area of code
- improving an error message
- removing an unnecessary method