### PR TITLE
♻️ Rework data error reference

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -153,9 +153,9 @@ class Question < ApplicationRecord
       return unless row['PART_OF']
       parent_question = questions[row['PART_OF']]
       if parent_question
-        errors.add(:data, "expected PART_OF to be one of #{Question.type_names_that_have_parts.join(', ')}, got #{parent_question.type_name}.") unless parent_question.has_parts?
+        errors.add(:base, "expected PART_OF to be one of #{Question.type_names_that_have_parts.join(', ')}, got #{parent_question.type_name}.") unless parent_question.has_parts?
       else
-        errors.add(:data, "expected PART_OF value to be an IMPORT_ID of another row in the CSV.")
+        errors.add(:base, "expected PART_OF value to be an IMPORT_ID of another row in the CSV.")
       end
     end
 

--- a/app/models/question/bow_tie.rb
+++ b/app/models/question/bow_tie.rb
@@ -87,7 +87,7 @@ class Question::BowTie < Question
 
       return true if (expected & given) == expected
 
-      errors.add(:data, "expected columns #{expected.join(', ')} but was missing #{(expected - given).join(', ')} columns.")
+      errors.add(:base, "expected columns #{expected.join(', ')} but was missing #{(expected - given).join(', ')} columns.")
     end
 
     def validate_answers
@@ -96,7 +96,7 @@ class Question::BowTie < Question
 
       return true if (expected & given) == expected
 
-      errors.add(:data, "expected columns #{expected.join(', ')} but was missing #{(expected - given).join(', ')} columns.")
+      errors.add(:base, "expected columns #{expected.join(', ')} but was missing #{(expected - given).join(', ')} columns.")
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -119,7 +119,7 @@ class Question::BowTie < Question
 
       index_errors.each_pair do |direction, columns|
         next if errors.blank?
-        errors.add(:data, %(#{direction.upcase}_ANSWERS should reference only #{direction.upcase}_<INTEGER> columns; instead got #{columns.map { |c| "#{direction.upcase}_#{c}" }.join(', ')}.))
+        errors.add(:base, %(#{direction.upcase}_ANSWERS should reference only #{direction.upcase}_<INTEGER> columns; instead got #{columns.map { |c| "#{direction.upcase}_#{c}" }.join(', ')}.))
       end
 
       given_answer_columns = row.headers.each_with_object({}) do |header, hash|
@@ -138,7 +138,7 @@ class Question::BowTie < Question
         given = given_answer_columns.fetch(direction, []).sort
         next if (expected & given) == expected
 
-        errors.add(:data, "expected columns #{expected.join(', ')} but was missing #{(expected - given).join(', ')} columns.")
+        errors.add(:base, "expected columns #{expected.join(', ')} but was missing #{(expected - given).join(', ')} columns.")
       end
     end
     # rubocop:enable Metrics/AbcSize
@@ -156,12 +156,12 @@ class Question::BowTie < Question
   # rubocop:disable Metrics/PerceivedComplexity
   def well_formed_serialized_data
     unless data.is_a?(Hash)
-      errors.add(:data, "expected to be a Hash, got a #{data.class}")
+      errors.add(:base, "expected to be a Hash, got a #{data.class}")
       return false
     end
 
     unless data.keys.map(&:to_s).sort == EXPECTED_DATA_HASH_KEYS.sort
-      errors.add(:data, "expected data Hash keys to be #{EXPECTED_DATA_HASH_KEYS.inspect}, got #{data.keys.inspect}")
+      errors.add(:base, "expected data Hash keys to be #{EXPECTED_DATA_HASH_KEYS.inspect}, got #{data.keys.inspect}")
       return false
     end
 
@@ -188,23 +188,23 @@ class Question::BowTie < Question
   def __validate_is_a_hash(key, elements)
     if elements.is_a?(Hash)
       return true if elements.key?(:answers) && elements.key?(:label)
-      errors.add(:data, "expected #{key} to be a Hash with keys of 'answers' and 'label'")
+      errors.add(:base, "expected #{key} to be a Hash with keys of 'answers' and 'label'")
     else
-      errors.add(:data, "expected #{key} to be a Hash, got a #{elements.class}")
+      errors.add(:base, "expected #{key} to be a Hash, got a #{elements.class}")
       false
     end
   end
 
   def __validate_answers_structure(key, answers)
     unless answers.is_a?(Array)
-      errors.add(:data, "expected #{key} answers to be an Array, got #{answers.class}.")
+      errors.add(:base, "expected #{key} answers to be an Array, got #{answers.class}.")
       return false
     end
 
     return true if answers.all? do |a|
                      a.is_a?(Hash) && a.keys.sort == ['answer', 'correct'] && a['answer'].is_a?(String) && a['answer'].present? && (a['correct'].is_a?(TrueClass) || a['correct'].is_a?(FalseClass))
                    end
-    errors.add(:data, "expected #{key} answers to be an Array of Arrays; the sub-array having the first element being a String and the second being a Boolean.")
+    errors.add(:base, "expected #{key} answers to be an Array of Arrays; the sub-array having the first element being a String and the second being a Boolean.")
 
     false
   end
@@ -213,21 +213,21 @@ class Question::BowTie < Question
     count = answers.count { |answer| answer['correct'] == true }
     return true if count == 1
 
-    errors.add(:data, "expected #{key}'s answers to have one and only one correct value; got #{count}.")
+    errors.add(:base, "expected #{key}'s answers to have one and only one correct value; got #{count}.")
     false
   end
 
   def __validate_at_least_one_true_answer(key, answers)
     return true unless answers.none? { |answer| answer['correct'] == true }
 
-    errors.add(:data, "expected #{key}'s answers to have at least one correct value; got none.")
+    errors.add(:base, "expected #{key}'s answers to have at least one correct value; got none.")
     false
   end
 
   def __validate_label_structure(key, label)
     return true if label.is_a?(String) && label.present?
 
-    errors.add(:data, "expected #{key}'s label to be a non-blank String")
+    errors.add(:base, "expected #{key}'s label to be a non-blank String")
     false
   end
 end

--- a/app/models/question/drag_and_drop.rb
+++ b/app/models/question/drag_and_drop.rb
@@ -46,11 +46,11 @@ class Question::DragAndDrop < Question
       if intersect != answers_as_column_names
         message = "ANSWERS column indicates that #{answers_as_column_names.join(', ')} " \
                   "columns should be the correct answer, but there's a mismatch with the provided ANSWER_ columns."
-        errors.add(:data, message)
+        errors.add(:base, message)
       end
       correct_answers = data.select { |pair| pair['correct'] }
       return unless correct_answers.count.zero?
-      errors.add(:data, "expected at least one correct answer, but no correct answers were specified.")
+      errors.add(:base, "expected at least one correct answer, but no correct answers were specified.")
       false
     end
 
@@ -123,12 +123,12 @@ class Question::DragAndDrop < Question
   # rubocop:disable Metrics/AbcSize
   def well_formed_serialized_data
     unless data.is_a?(Array)
-      errors.add(:data, "expected to be an array, got #{data.class.inspect}")
+      errors.add(:base, "expected to be an array, got #{data.class.inspect}")
       return false
     end
 
     unless data.all? { |pair| pair.is_a?(Hash) && pair.keys.sort == ['answer', 'correct'] && pair['answer'].is_a?(String) && pair['answer'].present? }
-      errors.add(:data, "expected to be an array of hashs, each sub-array having an answer and correct element, the answers being strings")
+      errors.add(:base, "expected to be an array of hashs, each sub-array having an answer and correct element, the answers being strings")
       return false
     end
 
@@ -140,16 +140,16 @@ class Question::DragAndDrop < Question
         text_slots = slot_numbers_from_text
 
         if answer_slots.sort != text_slots.sort
-          errors.add(:data, "mismatch of declared slots in text and answers")
+          errors.add(:base, "mismatch of declared slots in text and answers")
           return false
         end
       else
-        errors.add(:data, "expected all answers to either map to a text slot or to be false.  Instead have answers marked as True.")
+        errors.add(:base, "expected all answers to either map to a text slot or to be false.  Instead have answers marked as True.")
       end
     end
 
     if sub_type == SUB_TYPE_ATA && candidates.any? { |candidate| !(candidate.is_a?(TrueClass) || candidate.is_a?(FalseClass)) }
-      errors.add(:data, "expected all answer candidates to either be either: 1) all True and/or False, or 2) all Numeric or false.")
+      errors.add(:base, "expected all answer candidates to either be either: 1) all True and/or False, or 2) all Numeric or false.")
       return false
     end
 

--- a/app/models/question/invalid_type.rb
+++ b/app/models/question/invalid_type.rb
@@ -7,6 +7,6 @@
 # @see {Question}
 class Question::InvalidType < Question::InvalidQuestion
   def message
-    "row had TYPE of #{row['TYPE']} but expected to be one of the following: #{Question.descendants.map(&:type_name)}"
+    "row had TYPE of #{row['TYPE'].inspect} but expected to be one of the following: #{Question.descendants.map(&:type_name)}"
   end
 end

--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -54,7 +54,7 @@ class Question::Matching < Question
       message += " Have LEFT_#{left_has.join(', LEFT_')} columns without corresponding RIGHT_#{left_has.join(', RIGHT_')} columns." if left_has.any?
       right_has = @rights - @lefts
       message += " Have RIGHT_#{right_has.join(', RIGHT_')} columns without corresponding LEFT_#{right_has.join(', LEFT_')} columns." if right_has.any?
-      errors.add(:data, message)
+      errors.add(:base, message)
     end
   end
 
@@ -72,7 +72,7 @@ class Question::Matching < Question
   # rubocop:disable Metrics/CyclomaticComplexity
   def well_formed_serialized_data
     unless data.is_a?(Array)
-      errors.add(:data, "expected to be an array, got #{data.class.inspect}")
+      errors.add(:base, "expected to be an array, got #{data.class.inspect}")
       return false
     end
 
@@ -85,7 +85,7 @@ class Question::Matching < Question
       pair['correct'].is_a?(Array) &&
       pair['correct'].all?(&:present?)
     end
-      errors.add(:data, "expected to be an array of hashes, each hash having an answer and correct, both of which are strings")
+      errors.add(:base, "expected to be an array of hashes, each hash having an answer and correct, both of which are strings")
       return false
     end
 

--- a/app/models/question/scenario.rb
+++ b/app/models/question/scenario.rb
@@ -15,7 +15,7 @@ class Question::Scenario < Question
     end
 
     def validate_well_formed_row
-      errors.add(:data, "expected PART_OF column for CSV row.") unless row['PART_OF']
+      errors.add(:base, "expected PART_OF column for CSV row.") unless row['PART_OF']
     end
   end
 

--- a/app/models/question/select_all_that_apply.rb
+++ b/app/models/question/select_all_that_apply.rb
@@ -31,19 +31,19 @@ class Question::SelectAllThatApply < Question
     end
 
     def validate_well_formed_row
-      errors.add(:data, "expected ANSWERS column") unless row['ANSWERS']&.strip&.present?
+      errors.add(:base, "expected ANSWERS column") unless row['ANSWERS']&.strip&.present?
 
       answers_as_column_names = answers.map { |a| "ANSWER_#{a}" }
       intersect = (answers_as_column_names & answer_columns)
       if intersect != answers_as_column_names
         message = "ANSWERS column indicates that #{answers_as_column_names.join(', ')} " \
                   "columns should be the correct answer, but there's a mismatch with the provided ANSWER_ columns."
-        errors.add(:data, message)
+        errors.add(:base, message)
       end
 
       correct_answers = data.select { |pair| pair['correct'] == true }
       return unless correct_answers.count.zero?
-      errors.add(:data, "expected at least one correct answer, but no correct answers were specified.")
+      errors.add(:base, "expected at least one correct answer, but no correct answers were specified.")
       false
     end
   end
@@ -65,7 +65,7 @@ class Question::SelectAllThatApply < Question
   # rubocop:disable Metrics/MethodLength
   def well_formed_serialized_data
     unless data.is_a?(Array)
-      errors.add(:data, "expected to be an array, got #{data.class.inspect}")
+      errors.add(:base, "expected to be an array, got #{data.class.inspect}")
       return false
     end
 
@@ -75,7 +75,7 @@ class Question::SelectAllThatApply < Question
       pair['answer'].present? && pair['answer'].is_a?(String) &&
       pair['answer'].present? && (pair['correct'].is_a?(TrueClass) || pair['correct'].is_a?(FalseClass))
     end
-      errors.add(:data, "expected to be an array of arrays, each sub-array having two elements, both of which are strings")
+      errors.add(:base, "expected to be an array of arrays, each sub-array having two elements, both of which are strings")
       return false
     end
 
@@ -83,7 +83,7 @@ class Question::SelectAllThatApply < Question
     correct_answers = data.select { |pair| pair['correct'] == true }
 
     if correct_answers.count.zero?
-      errors.add(:data, "expected one correct answer, but no correct answers were specified.")
+      errors.add(:base, "expected one correct answer, but no correct answers were specified.")
       return false
     end
 

--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -23,7 +23,7 @@ class Question::StimulusCaseStudy < Question
     def validate_well_formed_row
       return unless row['PART_OF']
 
-      errors.add(:data, "A #{question.type_name} cannot be part of another question.")
+      errors.add(:base, "A #{question.type_name} cannot be part of another question.")
     end
   end
 

--- a/app/models/question/traditional.rb
+++ b/app/models/question/traditional.rb
@@ -31,14 +31,14 @@ class Question::Traditional < Question
 
     # rubocop:disable Metrics/AbcSize
     def validate_well_formed_row
-      errors.add(:data, "expected ANSWERS column") unless row['ANSWERS']&.strip&.present?
+      errors.add(:base, "expected ANSWERS column") unless row['ANSWERS']&.strip&.present?
 
       if answers.size == 1
         if answer_columns.exclude?("ANSWER_#{answers.first}")
-          errors.add(:data, "ANSWERS column indicates that ANSWER_#{answers.first} column should be the correct answer, but there is no ANSWER_#{answers.first}")
+          errors.add(:base, "ANSWERS column indicates that ANSWER_#{answers.first} column should be the correct answer, but there is no ANSWER_#{answers.first}")
         end
       else
-        errors.add(:data, "expected ANSWERS cell to have one correct answer.  The following columns are marked as correct answers: #{answers.map { |a| "ANSWER_#{a}" }.join(',')}")
+        errors.add(:base, "expected ANSWERS cell to have one correct answer.  The following columns are marked as correct answers: #{answers.map { |a| "ANSWER_#{a}" }.join(',')}")
       end
     end
     # rubocop:enable Metrics/AbcSize
@@ -62,12 +62,12 @@ class Question::Traditional < Question
   # rubocop:disable Metrics/AbcSize
   def well_formed_serialized_data
     unless data.is_a?(Array)
-      errors.add(:data, "expected to be a Array, got #{data.class.inspect}")
+      errors.add(:base, "expected to be a Array, got #{data.class.inspect}")
       return false
     end
 
     unless data.all? { |pair| pair.is_a?(Hash) && pair.keys.sort == ['answer', 'correct'] && pair['answer'].is_a?(String) && (pair['correct'].is_a?(TrueClass) || pair['correct'].is_a?(FalseClass)) }
-      errors.add(:data, "expected to be an array of hashes, each hash an answer and correct element, the answer being a string and the correct being a boolean")
+      errors.add(:base, "expected to be an array of hashes, each hash an answer and correct element, the answer being a string and the correct being a boolean")
       return false
     end
 
@@ -75,10 +75,10 @@ class Question::Traditional < Question
     correct_answers = data.select { |pair| pair['correct'] == true }
 
     if correct_answers.count.zero?
-      errors.add(:data, "expected one correct answer, but no correct answers were specified.")
+      errors.add(:base, "expected one correct answer, but no correct answers were specified.")
       return false
     elsif correct_answers.count > 1
-      errors.add(:data, "expected only one correct answer, but instead have #{correct_answers.count} correct answers.")
+      errors.add(:base, "expected only one correct answer, but instead have #{correct_answers.count} correct answers.")
       return false
     end
 

--- a/spec/fixtures/files/invalid_questions.csv
+++ b/spec/fixtures/files/invalid_questions.csv
@@ -1,2 +1,10 @@
-TYPE,TEXT
-Cookie Crunch, Fun times
+IMPORT_ID, TYPE,TEXT, ANSWERS, ANSWER_1, ANSWER_2
+1, ,Invalid: Missing TYPE,1,A1,A2
+,Traditional,Invalid: Missing IMPORT_ID,1,A1,A2
+3,Bogus,Invalid: TYPE unknown,1,A1,A2
+4,Traditional,Invalid: Specified answer column does not exist,300,A1,A2
+5,Traditional,Invalid: Multiple answers when only one allowed,"1,2",A1,A2
+6,Traditional,Valid: Yet won't import because others are invalid,1,A1,A2
+7,Traditional,Invalid: No correct answer given,,A1,A2
+8,Traditional,Invalid: Column name specified,ANSWER_1,A1,A2
+9,Select All That Apply,Invalid: No correct answer given,,A1,A2

--- a/spec/models/question/traditional_spec.rb
+++ b/spec/models/question/traditional_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Question::Traditional do
     subject { described_class.build_row(row: data, questions: {}) }
 
     [
-      [{ "ANSWERS" => "2", "ANSWER_1" => "Hello World!" }, /Data ANSWERS column indicates that ANSWER_2/],
+      [{ "ANSWERS" => "2", "ANSWER_1" => "Hello World!" }, /ANSWERS column indicates that ANSWER_2/],
       [{ "ANSWERS" => "1,2", "ANSWER_1" => "A1", "ANSWER_2" => "A2" }, /expected ANSWERS cell to have one correct answer/],
       [{ "ANSWER_1" => "A1", "ANSWER_2" => "A2" }, /expected ANSWERS cell to have one correct answer/]
     ].each do |given_data, error_message|


### PR DESCRIPTION
Prior to this commit, the error messages for the CSV were not
propogating to the UI.

With this change, the error messages regarding CSV are now propogated to
the UI.

Related to:

- https://github.com/scientist-softserv/viva/issues/164

<details><summary>Before</summary>
<img width="1272" alt="Screenshot 2023-11-02 at 1 04 18 PM" src="https://github.com/scientist-softserv/viva/assets/2130/fe3d79e1-d1a5-437e-b2c3-fc94bea5110b">

</details>


<details><summary>After</summary>
<img width="1167" alt="Screenshot 2023-11-02 at 1 16 39 PM" src="https://github.com/scientist-softserv/viva/assets/2130/014a87a6-17b4-487e-9189-7e6c306fab63">
</details>


</details>