### PR TITLE
♻️ Improve legibility of error message

### DIFF
--- a/app/javascript/components/pages/Uploads/index.jsx
+++ b/app/javascript/components/pages/Uploads/index.jsx
@@ -90,7 +90,7 @@ const Uploads = (props) => {
                 {/* errors on the row level */}
                 {responseErrors?.rows && responseErrors.rows.map((row, index) => (
                   <p key={index} className='small'>
-                    <span><b>Row with import ID {row.import_id}:</b> {row.base ? row.base : 'Please check that all data is entered correctly in each cell'}</span>
+                    <span><b>Row with import ID {row.import_id}:</b> {row.base ? [row.base].flat().join('; '): 'Please check that all data is entered correctly in each cell'}</span>
                   </p>
                 ))}
               </>

--- a/app/models/question/invalid_type.rb
+++ b/app/models/question/invalid_type.rb
@@ -7,6 +7,6 @@
 # @see {Question}
 class Question::InvalidType < Question::InvalidQuestion
   def message
-    "row had TYPE of #{row['TYPE'].inspect} but expected to be one of the following: #{Question.descendants.map(&:type_name)}"
+    "row had TYPE of #{row['TYPE'].inspect} but expected to be one of the following: #{Question.descendants.map(&:type_name).join(', ')}"
   end
 end


### PR DESCRIPTION
Prior to this commit, when `row.base` was multi-element, the text was joined with an empty string.  This created clunky UI.

Also prior to this commit, the list of question types was showing as a Ruby array.  Not quite helpful.

<details open><summary>Before Screenshot</summary>
<img width="1215" alt="Screenshot 2023-11-09 at 11 25 26 AM" src="https://github.com/scientist-softserv/viva/assets/2130/9798695e-8fda-4b85-90f9-c790f373c227">

</details>


<details open><summary>After Screenshot</summary>
<img width="1233" alt="Screenshot 2023-11-09 at 11 22 25 AM" src="https://github.com/scientist-softserv/viva/assets/2130/363b9dd3-e033-44b8-8795-e7de2cc3c33f">

</details>

Related to:

- https://github.com/scientist-softserv/viva/issues/164