### PR TITLE
🐛 Expose route for download of XML

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     authenticated :user do
       # search page routes
       root 'search#index', as: :authenticated_root
+
+      # Necessary for downloading the XML file from the search result.
+      get '/(.:format)', to: 'search#index'
+
       # settings page routes
       get '/settings', to: 'settings#index', as: 'settings'
       patch '/settings/update', to: 'settings#update'


### PR DESCRIPTION
Prior to this commit, the only format type for the `/` route was HTML.

With this commit, we're exposing logic to handl the `/.xml` route.

(I'd love to refactor the routes on this application but dread that
given the interplay with React)