### PR TITLE
🎁 Provide HTML output of data for "Rich Text" questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'pry-byebug', group: %i[development test]
 gem 'puma', '~> 5.0' # Use the Puma web server [https://github.com/puma/puma]
 gem 'rails', '~> 7.0.5' # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails-controller-testing' # Exposes the assigns method used in controller testing
+gem 'redcarpet', '~> 3.6'
 gem 'rspec-its', group: %i[development test]
 gem 'rspec-rails', group: %i[development test]
 gem 'rubocop-rails', require: false, group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
     rake (13.1.0)
     rdoc (6.5.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.8.2)
     reline (0.3.9)
       io-console (~> 0.5)
@@ -384,6 +385,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.5)
   rails-controller-testing
+  redcarpet (~> 3.6)
   rspec-its
   rspec-rails
   rubocop-rails

--- a/app/models/question/essay.rb
+++ b/app/models/question/essay.rb
@@ -2,6 +2,9 @@
 
 ##
 # One question that involves a lengthy introduction to the concept and has a "Rich Text" ask.
+#
+# @note the {#data} attribute will be a Hash with one key: "html".  That "html" will be safe to
+#       render in the UI.
 class Question::Essay < Question
   self.type_name = "Essay"
 

--- a/app/models/question/upload.rb
+++ b/app/models/question/upload.rb
@@ -3,6 +3,9 @@
 ##
 # One question that involves a lengthy introduction to the concept and has a "Rich Text" ask; and
 # requires the answer to be an uploaded file.
+#
+# @note the {#data} attribute will be a Hash with one key: "html".  That "html" will be safe to
+#       render in the UI.
 class Question::Upload < Question
   self.type_name = "Upload"
 

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -130,7 +130,7 @@ FactoryBot.define do
     end
 
     factory :question_essay, class: Question::Essay, parent: :question do
-      data { { "markdown" => "Hello\n* World\n\nLink to [Samvera](https://samvera.org)" } }
+      data { { "html" => "<p>Hello</p><ul><li>World</li><li>Link to <a href='https://samvera.org'>Samvera</a></li></ul>" } }
     end
 
     factory :question_matching, class: Question::Matching, parent: :question do
@@ -177,7 +177,7 @@ FactoryBot.define do
     end
 
     factory :question_upload, class: Question::Upload, parent: :question do
-      data { { "markdown" => "Hello\n* World\n\nLink to [Samvera](https://samvera.org)" } }
+      data { { "html" => "<p>Hello</p><ul><li>World</li><li>Link to <a href='https://samvera.org'>Samvera</a></li></ul>" } }
     end
   end
 end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -185,13 +185,16 @@ RSpec.shared_examples 'a Markdown Question' do
         CsvRow.new("TYPE" => described_class.type_name,
                    "TEXT" => "Title of Question",
                    "TEXT_1" => "* Bullet Point",
+                   "TEXT_2" => "* Second Point",
+                   "TEXT_3" => "<script>alert('Hello');</script>",
                    "KEYWORD" => "One, Two",
                    "SUBJECT" => "Big, Little")
       end
 
       it { is_expected.to be_valid }
       it { is_expected.not_to be_persisted }
-      its(:data) { is_expected.to eq({ "markdown" => "Title of Question\n* Bullet Point" }) }
+      let(:expected_html) { "<p>Title of Question</p><ul><li><p>Bullet Point</p></li><li><p>Second Point</p></li></ul>" }
+      its(:data) { is_expected.to eq({ "html" => expected_html }) }
 
       it 'will save the underlying record' do
         expect { subject.save }.to change(described_class, :count).by(1)


### PR DESCRIPTION
Prior to this commit, we were exposing markdown as part of the data for rendering on the client side.

After discussion with team members and thinking through the implications, we chose to switch to providing the React front-end with HTML.

The thought being:

1. We can sanitize the HTML according to consistent server rules; which will be similar logic we'd provide during the export of data to QTI format.  And since the export format will come from the server, it makes sense for the server to handle the markdown to HTML conversion and sanitization.
2. By providing HTML, we're telling the client-side application that we're promising HTML.  Something that is a more reasonable promise than Markdown.
   - While markdown might be straight forward, it could be a volatile decsion related to the eventual import strategy(s) of the site. That is to say, if we pivot away from the CSV, it's possible that we might get QTI, which would contain a smattering of HTML nodes.

With this commit, we're providing HTML.

Related to:

- https://github.com/scientist-softserv/viva/issues/174
- https://github.com/scientist-softserv/viva/issues/175