### PR TITLE
Reuse the component for Matching for Categorization question types

### DIFF
--- a/app/javascript/components/ui/Answers/index.jsx
+++ b/app/javascript/components/ui/Answers/index.jsx
@@ -18,7 +18,7 @@ const Answers = ({ question_type_name, answers }) => {
       {question_type_name === 'Drag And Drop' && (
         <DragAndDropAnswers answers={answers} />
       )}
-      {question_type_name === 'Matching' && (
+      {(question_type_name === 'Matching' || question_type_name === 'Categorization') && (
         <MatchingAnswers answers={answers} />
       )}
       {/* Traditional and SATA types use the same format */}


### PR DESCRIPTION
# Summary
- Categorization data is mostly identical to matching data. This change reuses the Matching component for the categorization question types 

- An example of a Categorization question that uses chronological order. Note that in the current implementation, the user will still need to fill in something for both the left1 and right1 cell for this question type. 
<img width="1162" alt="image" src="https://github.com/scientist-softserv/viva/assets/73361970/cac614bf-3137-4cb0-acb7-23421bff0b20">

# Screenshot
<img width="1161" alt="image" src="https://github.com/scientist-softserv/viva/assets/73361970/92fe49a3-8a67-42f7-8d19-311a79eef7a0">

