### PR TITLE
🎁 Add QTI XML export for Matching question

### DIFF
--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -11,4 +11,61 @@ class Question::Matching < Question
   end
 
   include MatchingQuestionBehavior
+
+  ##
+  # @!group QTI Exporter
+  #
+  # @!attribute qti_max_value [r|w]
+  #   @return [Integer]
+  class_attribute :qti_max_value, default: 100
+
+  self.export_as_xml = true
+
+  def qti_choices
+    return @qti_choices if defined?(@qti_choices)
+    build_qti_data
+    @qti_choices
+  end
+
+  def qti_responses
+    return @qti_responses if defined?(@qti_responses)
+    build_qti_data
+    @qti_responses
+  end
+
+  def qti_response_conditions
+    return @qti_response_conditions if defined?(@qti_response_conditions)
+    build_qti_data
+    @qti_response_conditions
+  end
+
+  private
+
+  Choice = Struct.new(:ident, :text, keyword_init: true)
+  Response = Choice
+  ResponseCondition = Struct.new(:choice, :response, :value, keyword_init: true) do
+    delegate :ident, :text, to: :choice, prefix: true
+    delegate :ident, :text, to: :response, prefix: true
+  end
+
+  def build_qti_data
+    @qti_responses = []
+    @qti_choices = []
+    @qti_response_conditions = []
+
+    # We're assigning proportional value to each correct answer; we're making an assumption of 2
+    # decimals of precision based on provided examples.
+    value = format("%0.2f", qti_max_value.to_f / data.count)
+    data.each_with_index do |datum, index|
+      choice = Choice.new(ident: "#{item_ident}-c-#{index}", text: datum.fetch('answer'))
+      @qti_choices << choice
+      # HACK: There are examples of matching questions where a choice has multiple correct
+      # responses; I don't know how we're resolving that; hence the hack.
+      response = Response.new(ident: "#{item_ident}-r-#{index}", text: Array.wrap(datum.fetch('correct')).first)
+      @qti_responses << response
+      @qti_response_conditions << ResponseCondition.new(value:, response:, choice:)
+    end
+  end
+  # @!endgroup QTI Exporter
+  ##
 end

--- a/app/views/question/matchings/_matching.xml.erb
+++ b/app/views/question/matchings/_matching.xml.erb
@@ -1,0 +1,56 @@
+<item ident="<%= matching.item_ident %>" title="Question <%= matching.id %>" >
+  <itemmetadata>
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>question_type</fieldlabel>
+        <fieldentry>matching_question</fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>points_possible</fieldlabel>
+        <fieldentry>1.0</fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>original_answer_ids</fieldlabel>
+        <fieldentry><%= matching.qti_choices.map(&:ident).join(',') %></fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>assessment_question_identifierref</fieldlabel>
+        <fieldentry><%= matching.assessment_question_identifierref %></fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+  </itemmetadata>
+  <presentation>
+    <material>
+      <mattext texttype="text/plain"><%= matching.text %></mattext>
+    </material>
+    <% matching.qti_choices.each do |choice| %>
+      <response_lid ident="<%= choice.ident %>">
+	<material>
+          <mattext texttype="text/plain"><%= choice.text %></mattext>
+	</material>
+	<render_choice>
+	  <% matching.qti_responses.each do |qresponse| %>
+            <response_label ident="<%= qresponse.ident %>">
+              <material>
+		<mattext><%= qresponse.text %></mattext>
+              </material>
+            </response_label>
+	  <% end %>
+      </render_choice>
+      </response_lid>
+    <% end %>
+  </presentation>
+  <resprocessing>
+    <outcomes>
+      <decvar maxvalue="<%= matching.qti_max_value %>" minvalue="0" varname="SCORE" vartype="Decimal"/>
+    </outcomes>
+    <% matching.qti_response_conditions.each do |condition| %>
+      <respcondition>
+	<conditionvar>
+          <varequal respident="<%= condition.choice_ident %>"><%= condition.response_ident %></varequal>
+	</conditionvar>
+	<setvar varname="SCORE" action="Add"><%= condition.value %></setvar>
+      </respcondition>
+    <% end %>
+  </resprocessing>
+</item>

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -3,8 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Question::Matching do
-  it_behaves_like "a Question"
+  it_behaves_like "a Question", export_as_xml: true
   it_behaves_like "a Matching Question"
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Matching") }
+  its(:qti_max_value) { is_expected.to be_a(Integer) }
+
+  let(:instance) { FactoryBot.build(:question_matching) }
+
+  describe '#qti_choices' do
+    it "is an Array of Choice objects" do
+      expect(instance.qti_choices.all? { |r| r.is_a?(described_class::Choice) }).to be_truthy
+    end
+  end
+
+  describe '#qti_response_conditions' do
+    it "is an Array of ResponseCondition objects" do
+      expect(instance.qti_response_conditions.all? { |r| r.is_a?(described_class::ResponseCondition) }).to be_truthy
+    end
+  end
+
+  describe '#qti_responses' do
+    it "is an Array of Response objects" do
+      expect(instance.qti_responses.all? { |r| r.is_a?(described_class::Response) }).to be_truthy
+    end
+  end
 end

--- a/spec/views/question/matchings/_matching.xml.erb_spec.rb
+++ b/spec/views/question/matchings/_matching.xml.erb_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'question/matchings/_matching' do
+  let(:matching) { FactoryBot.build(:question_matching) }
+
+  it 'renders xml' do
+    render partial: "question/matchings/matching", locals: { matching: }
+    expect(rendered).to include(%(<item ident="#{matching.item_ident}" title="Question #{matching.id}" >))
+    # Unlike Question::Categorization; the matching does not allow for multiple.
+    # See https://github.com/scientist-softserv/viva/issues/237
+    expect(rendered).not_to include(%(rcardinality="Multiple">))
+    expect(rendered).to include(%(<fieldentry>matching_question</fieldentry>))
+  end
+end


### PR DESCRIPTION
On <2023-12-11 Mon> I verified with the client that the exported XML for Matching questions does import into Canvas.

Related to:

- https://github.com/scientist-softserv/viva/issues/166
- https://github.com/scientist-softserv/viva/issues/170