### PR TITLE
♻️ Add cardinality and unique validation to Matching behavior

### DIFF
--- a/app/models/concerns/matching_question_behavior.rb
+++ b/app/models/concerns/matching_question_behavior.rb
@@ -13,10 +13,13 @@ module MatchingQuestionBehavior
   #
   # @see {#validate_well_formed_row}
   class ImportCsvRow < Question::ImportCsvRow
+    delegate :choice_cardinality_is_multiple?, to: :question_type
     ##
     # @see #validate_well_formed_row
     #
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def extract_answers_and_data_from(row)
       # These are reused in #validate_well_formed_row
       @lefts = []
@@ -38,21 +41,59 @@ module MatchingQuestionBehavior
         # It is okay that these will possibly be nil; because our downstream validation will catch
         # them.
         answer = row["LEFT_#{index}"]
-        correct = row["RIGHT_#{index}"]&.split(/\s*,\s*/)
+        correct = row["RIGHT_#{index}"]&.split(/\s*,\s*/)&.map(&:strip)
         next if answer.blank? && correct.blank?
         array << { "answer" => answer, "correct" => correct }
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/MethodLength
 
     def validate_well_formed_row
-      return unless @lefts.sort != @rights.sort
+      validate_matching_lefts_and_rights
+      validate_uniquenss_of_correct_choice
+      validate_choice_cardinality
+    end
+
+    def validate_matching_lefts_and_rights
+      return if @lefts.sort == @rights.sort
+
       message = "mismatch of LEFT and RIGHT columns."
       left_has = @lefts - @rights
       message += " Have LEFT_#{left_has.join(', LEFT_')} columns without corresponding RIGHT_#{left_has.join(', RIGHT_')} columns." if left_has.any?
       right_has = @rights - @lefts
       message += " Have RIGHT_#{right_has.join(', RIGHT_')} columns without corresponding LEFT_#{right_has.join(', LEFT_')} columns." if right_has.any?
       errors.add(:base, message)
+    end
+
+    def validate_uniquenss_of_correct_choice
+      corrects = @rights.flat_map { |index| row["RIGHT_#{index}"]&.split(/\s*,\s*/) }.compact.map(&:strip)
+      corrects_no_dups = corrects.uniq
+      return true if corrects_no_dups.size == corrects.size
+      dups = []
+      corrects_no_dups.each do |text|
+        next unless corrects.count(text) > 1
+        dups << text
+      end
+      return true if dups.none?
+
+      errors.add(:base, %(expected "#{dups.join('", "')}" to be unique within RIGHT columns))
+    end
+
+    def validate_choice_cardinality
+      return true if choice_cardinality_is_multiple?
+
+      invalids = []
+      @rights.each do |index|
+        header_name = "RIGHT_#{index}"
+        next if row[header_name].blank?
+        next unless row[header_name].split(/\s*,\s*/).size > 1
+        invalids << header_name
+      end
+      return true if invalids.none?
+
+      errors.add(:base, %(expected columns "#{invalids.join('", "')}" to have one and only one answer.))
     end
   end
 
@@ -61,7 +102,9 @@ module MatchingQuestionBehavior
     # for the data to be used in the application, beyond export of data, is minimal.
     serialize :data, JSON
     validate :well_formed_serialized_data
-    validates :data, presence: true
+    class_attribute :choice_cardinality_is_multiple, default: false
+
+    class_attribute :response_cardinality_is_multiple, default: false
   end
 
   ##
@@ -70,9 +113,15 @@ module MatchingQuestionBehavior
   #
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def well_formed_serialized_data
     unless data.is_a?(Array)
       errors.add(:base, "expected to be an array, got #{data.class.inspect}")
+      return false
+    end
+
+    if data.empty?
+      errors.add(:base, "expected to be a non-empty array.")
       return false
     end
 
@@ -91,19 +140,16 @@ module MatchingQuestionBehavior
 
     true
   end
+  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/MethodLength
 
   def qti_choices
-    return @qti_choices if defined?(@qti_choices)
-    build_qti_data
-    @qti_choices
+    @qti_choices ||= qti_response_conditions.flat_map(&:choices)
   end
 
   def qti_responses
-    return @qti_responses if defined?(@qti_responses)
-    build_qti_data
-    @qti_responses
+    @qti_responses ||= qti_response_conditions.flat_map(&:response)
   end
 
   def qti_response_conditions
@@ -116,26 +162,27 @@ module MatchingQuestionBehavior
 
   Choice = Struct.new(:ident, :text, keyword_init: true)
   Response = Choice
-  ResponseCondition = Struct.new(:choice, :responses, :value, keyword_init: true) do
-    delegate :ident, :text, to: :choice, prefix: true
+  ResponseCondition = Struct.new(:choices, :response, :value, keyword_init: true) do
+    delegate :ident, :text, to: :response, prefix: true
   end
 
   def build_qti_data
-    @qti_responses = []
-    @qti_choices = []
     @qti_response_conditions = []
 
     # We're assigning proportional value to each correct answer; we're making an assumption of 2
     # decimals of precision based on provided examples.
     value = format("%0.2f", qti_max_value.to_f / data.count)
+
+    # We want the choice index to be unique
+    choice_index = 0
     data.each_with_index do |datum, index|
-      choice = Choice.new(ident: "#{item_ident}-c-#{index}", text: datum.fetch('answer'))
-      @qti_choices << choice
-      # HACK: There are examples of matching questions where a choice has multiple correct
-      # responses; I don't know how we're resolving that; hence the hack.
-      response = Response.new(ident: "#{item_ident}-r-#{index}", text: Array.wrap(datum.fetch('correct')).first)
-      @qti_responses << response
-      @qti_response_conditions << ResponseCondition.new(value:, responses: [response], choice:)
+      choices = []
+      Array.wrap(datum.fetch('correct')).each do |choice|
+        Choice.new(ident: "#{item_ident}-c-#{choice_index}", text: choice)
+        choice_index += 1
+      end
+      response = Response.new(ident: "#{item_ident}-r-#{index}", text: datum.fetch('answer'))
+      @qti_response_conditions << ResponseCondition.new(value:, response:, choices:)
     end
   end
   # @!endgroup QTI Exporter

--- a/app/models/question/categorization.rb
+++ b/app/models/question/categorization.rb
@@ -11,4 +11,6 @@ class Question::Categorization < Question
   end
 
   include MatchingQuestionBehavior
+
+  self.choice_cardinality_is_multiple = true
 end

--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -12,4 +12,6 @@ class Question::Matching < Question
   end
 
   include MatchingQuestionBehavior
+
+  self.choice_cardinality_is_multiple = false
 end

--- a/app/views/question/categorizations/_categorization.xml.erb
+++ b/app/views/question/categorizations/_categorization.xml.erb
@@ -23,36 +23,36 @@
     <material>
       <mattext texttype="text/plain"><%= categorization.text %></mattext>
     </material>
-    <%- categorization.qti_choices.each do |choice| %>
-      <response_lid ident="<%= choice.ident %>" rcardinality="Multiple">
+    <% categorization.qti_responses.each do |response| %>
+      <response_lid ident="<%= response.ident %>" rcardinality="Multiple">
 	<material>
-          <mattext texttype="text/plain"><%= choice.text %></mattext>
+          <mattext texttype="text/plain"><%= response.text %></mattext>
 	</material>
 	<render_choice>
-	  <%- categorization.qti_responses.each do |qresponse| %>
-            <response_label ident="<%= qresponse.ident %>">
+	  <% categorization.qti_choices.each do |choice| %>
+            <response_label ident="<%= choice.ident %>">
               <material>
-		<mattext><%= qresponse.text %></mattext>
+		<mattext><%= choice.text %></mattext>
               </material>
             </response_label>
-	  <%- end %>
+	  <% end %>
       </render_choice>
       </response_lid>
-    <%- end %>
+    <% end %>
   </presentation>
   <resprocessing>
     <outcomes>
       <decvar maxvalue="<%= categorization.qti_max_value %>" minvalue="0" varname="SCORE" vartype="Decimal"/>
     </outcomes>
-    <%- categorization.qti_response_conditions.each do |condition| %>
+    <% categorization.qti_response_conditions.each do |condition| %>
       <respcondition>
 	<conditionvar>
-	  <%- condition.responses.each do |response| %>
-          <varequal respident="<%= condition.choice_ident %>"><%= response.ident %></varequal>
+	  <%- condition.choices.each do |choice| %>
+            <varequal respident="<%= condition.response_ident %>"><%= choice.ident %></varequal>
 	  <%- end %>
 	</conditionvar>
 	<setvar varname="SCORE" action="Add"><%= condition.value %></setvar>
       </respcondition>
-    <%- end %>
+    <% end %>
   </resprocessing>
 </item>

--- a/app/views/question/matchings/_matching.xml.erb
+++ b/app/views/question/matchings/_matching.xml.erb
@@ -23,16 +23,16 @@
     <material>
       <mattext texttype="text/plain"><%= matching.text %></mattext>
     </material>
-    <% matching.qti_choices.each do |choice| %>
-      <response_lid ident="<%= choice.ident %>">
+    <% matching.qti_responses.each do |response| %>
+      <response_lid ident="<%= response.ident %>">
 	<material>
-          <mattext texttype="text/plain"><%= choice.text %></mattext>
+          <mattext texttype="text/plain"><%= response.text %></mattext>
 	</material>
 	<render_choice>
-	  <% matching.qti_responses.each do |qresponse| %>
-            <response_label ident="<%= qresponse.ident %>">
+	  <% matching.qti_choices.each do |choice| %>
+            <response_label ident="<%= choice.ident %>">
               <material>
-		<mattext><%= qresponse.text %></mattext>
+		<mattext><%= choice.text %></mattext>
               </material>
             </response_label>
 	  <% end %>
@@ -47,8 +47,8 @@
     <% matching.qti_response_conditions.each do |condition| %>
       <respcondition>
 	<conditionvar>
-	  <%- condition.responses.each do |response| %>
-            <varequal respident="<%= condition.choice_ident %>"><%= response.ident %></varequal>
+	  <%- condition.choices.each do |choice| %>
+            <varequal respident="<%= condition.response_ident %>"><%= choice.ident %></varequal>
 	  <%- end %>
 	</conditionvar>
 	<setvar varname="SCORE" action="Add"><%= condition.value %></setvar>

--- a/public/valid_categorization_question.csv
+++ b/public/valid_categorization_question.csv
@@ -1,2 +1,2 @@
-IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,LEFT_3,LEFT_4,LEFT_5,RIGHT_1,RIGHT_2,RIGHT_3,RIGHT_4,RIGHT_5
-1,Categorization,Arrange these Chinese dynasties into chronological order from oldest to most recent:,History,History,1,,,,,,Qin,Han,Shang,Ming,Yuan
+IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
+1,Categorization,Group the named elements by type:,History,History,1,Animal,Plan,"Cat, Dog","Dogwood,Catnip"

--- a/public/valid_matching_question.csv
+++ b/public/valid_matching_question.csv
@@ -1,2 +1,2 @@
-IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2,
-67890,Matching,Identify the selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs).,"SSRI, SNRI",Nursing,,Selective Serotonin Reuptake Inhibitors,Serotonin-norepinephrine reuptake Inhibitors,"Citalopram, Escitalopram, Paroxetine, Fluoxetine","Desvenlafaxine, Levomilnacipran, Duloxetine, Venlafaxine"
+IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
+67890,Matching,Identify the selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs).,"SSRI, SNRI",Nursing,,Selective Serotonin Reuptake Inhibitors,Serotonin-norepinephrine reuptake Inhibitors,"Citalopram","Desvenlafaxine"

--- a/spec/fixtures/files/valid_categorization_question.csv
+++ b/spec/fixtures/files/valid_categorization_question.csv
@@ -1,2 +1,2 @@
-IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,LEFT_3,LEFT_4,LEFT_5,RIGHT_1,RIGHT_2,RIGHT_3,RIGHT_4,RIGHT_5
-1,Categorization,Arrange these Chinese dynasties into chronological order from oldest to most recent:,History,History,1,First,Second,Third,Fourth,Fifth,Qin,Han,Shang,Ming,Yuan
+IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
+1,Categorization,Group the named elements by type:,History,History,1,Animal,Plan,"Cat, Dog","Dogwood,Catnip"

--- a/spec/fixtures/files/valid_matching_question.csv
+++ b/spec/fixtures/files/valid_matching_question.csv
@@ -1,2 +1,2 @@
 IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
-67890,Matching,Identify the selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs).,"SSRI, SNRI",Nursing,,Selective Serotonin Reuptake Inhibitors,Serotonin-norepinephrine reuptake Inhibitors,"Citalopram, Escitalopram, Paroxetine, Fluoxetine","Desvenlafaxine, Levomilnacipran, Duloxetine, Venlafaxine"
+67890,Matching,Identify the selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs).,"SSRI, SNRI",Nursing,,Selective Serotonin Reuptake Inhibitors,Serotonin-norepinephrine reuptake Inhibitors,"Citalopram","Desvenlafaxine"

--- a/spec/models/question/categorization_spec.rb
+++ b/spec/models/question/categorization_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Question::Categorization do
   it_behaves_like "a Matching Question"
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Categorization") }
+  its(:choice_cardinality_is_multiple?) { is_expected.to be_truthy }
 
   describe '.build_row' do
-    context 'for arrange answers in an order' do
+    context 'for cardinality validation' do
       subject { described_class.build_row(row:, questions: {}) }
 
       let(:row) do

--- a/spec/models/question/matching_spec.rb
+++ b/spec/models/question/matching_spec.rb
@@ -8,4 +8,29 @@ RSpec.describe Question::Matching do
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Matching") }
   its(:qti_max_value) { is_expected.to be_a(Integer) }
+  its(:choice_cardinality_is_multiple?) { is_expected.to be_falsey }
+
+  context '.build_data' do
+    subject { described_class.build_row(row:, questions: {}) }
+    let(:row) do
+      CsvRow.new("TYPE" => described_class.type_name,
+                 "TEXT" => "#{described_class.type_name} the proper pairings:",
+                 "LEVEL" => Level.names.first,
+                 "LEFT_1" => "Animal",
+                 "RIGHT_1" => "Cat, Dog",
+                 "LEFT_2" => "Plant",
+                 "RIGHT_2" => "Catnip, Dogwood",
+                 "KEYWORD" => "One, Two",
+                 "SUBJECT" => "Big, Little")
+    end
+
+    it { is_expected.not_to be_valid }
+    it { is_expected.not_to be_persisted }
+
+    it "will raise a message" do
+      expect(subject.question).not_to receive(:save!)
+      # I could have one regular expression for this, but figure splitting it apart helps show with clarity.
+      expect { subject.save! }.to raise_error(%r{expected columns "RIGHT_1", "RIGHT_2" to have one and only one answer})
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit Matching and Categorization had the same import logic.  However, the reality is that Matching allows only one to one answer/choice pairs.  Where as Categorization allows multiple correct elements per answer.

With this commit we introduce uniquness validation as well as cardinality validation; as defined in the specs.

There is still a consideration of naming.  The `LEFT_` and `RIGHT_` columns map to the bowtie concepts; but that's a digression.

Closes #237

See:

 - https://github.com/scientist-softserv/viva/issues/237