### PR TITLE
🎁 Enable export Categorization

### DIFF
--- a/app/models/concerns/matching_question_behavior.rb
+++ b/app/models/concerns/matching_question_behavior.rb
@@ -178,7 +178,7 @@ module MatchingQuestionBehavior
     data.each_with_index do |datum, index|
       choices = []
       Array.wrap(datum.fetch('correct')).each do |choice|
-        Choice.new(ident: "#{item_ident}-c-#{choice_index}", text: choice)
+        choices << Choice.new(ident: "#{item_ident}-c-#{choice_index}", text: choice)
         choice_index += 1
       end
       response = Response.new(ident: "#{item_ident}-r-#{index}", text: datum.fetch('answer'))

--- a/app/models/question/categorization.rb
+++ b/app/models/question/categorization.rb
@@ -5,12 +5,12 @@
 #
 # @see #well_formed_serialized_data
 class Question::Categorization < Question
+  include MatchingQuestionBehavior
+
   self.type_name = "Categorization"
+  self.export_as_xml = true
+  self.choice_cardinality_is_multiple = true
 
   class ImportCsvRow < MatchingQuestionBehavior::ImportCsvRow
   end
-
-  include MatchingQuestionBehavior
-
-  self.choice_cardinality_is_multiple = true
 end

--- a/app/models/question/matching.rb
+++ b/app/models/question/matching.rb
@@ -5,13 +5,12 @@
 #
 # @see #well_formed_serialized_data
 class Question::Matching < Question
+  include MatchingQuestionBehavior
+
   self.type_name = "Matching"
   self.export_as_xml = true
+  self.choice_cardinality_is_multiple = false
 
   class ImportCsvRow < MatchingQuestionBehavior::ImportCsvRow
   end
-
-  include MatchingQuestionBehavior
-
-  self.choice_cardinality_is_multiple = false
 end

--- a/public/valid_categorization_question.csv
+++ b/public/valid_categorization_question.csv
@@ -1,2 +1,2 @@
 IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
-1,Categorization,Group the named elements by type:,History,History,1,Animal,Plan,"Cat, Dog","Dogwood,Catnip"
+1,Categorization,Group the named elements by type:,History,History,1,Animal,Plant,"Cat, Dog","Dogwood,Catnip"

--- a/spec/fixtures/files/valid_categorization_question.csv
+++ b/spec/fixtures/files/valid_categorization_question.csv
@@ -1,2 +1,2 @@
 IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
-1,Categorization,Group the named elements by type:,History,History,1,Animal,Plan,"Cat, Dog","Dogwood,Catnip"
+1,Categorization,Group the named elements by type:,History,History,1,Animal,Plant,"Cat, Dog","Dogwood,Catnip"

--- a/spec/fixtures/files/valid_matching_question.csv
+++ b/spec/fixtures/files/valid_matching_question.csv
@@ -1,2 +1,2 @@
 IMPORT_ID,TYPE,TEXT,KEYWORD,SUBJECT,LEVEL,LEFT_1,LEFT_2,RIGHT_1,RIGHT_2
-67890,Matching,Identify the selective serotonin reuptake inhibitors (SSRIs) and serotonin-norepinephrine reuptake inhibitors (SNRIs).,"SSRI, SNRI",Nursing,,Selective Serotonin Reuptake Inhibitors,Serotonin-norepinephrine reuptake Inhibitors,"Citalopram","Desvenlafaxine"
+1,Matching,Group the named elements by type:,History,History,1,Color,Food,"Red","Potato"

--- a/spec/models/question/categorization_spec.rb
+++ b/spec/models/question/categorization_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Question::Categorization do
-  it_behaves_like "a Question"
+  it_behaves_like "a Question", export_as_xml: true
   it_behaves_like "a Matching Question"
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Categorization") }

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -175,22 +175,25 @@ RSpec.shared_examples 'a Matching Question' do
   end
 
   describe 'QTI Exporting' do
-    let(:instance) { FactoryBot.build(:question_matching) }
+    let(:instance) { FactoryBot.build("question_#{described_class.name.demodulize.underscore}") }
 
     describe '#qti_choices' do
       it "is an Array of Choice objects" do
+        expect(instance.qti_choices).to be_present
         expect(instance.qti_choices.all? { |r| r.is_a?(described_class::Choice) }).to be_truthy
       end
     end
 
     describe '#qti_response_conditions' do
       it "is an Array of ResponseCondition objects" do
+        expect(instance.qti_response_conditions).to be_present
         expect(instance.qti_response_conditions.all? { |r| r.is_a?(described_class::ResponseCondition) }).to be_truthy
       end
     end
 
     describe '#qti_responses' do
       it "is an Array of Response objects" do
+        expect(instance.qti_responses).to be_present
         expect(instance.qti_responses.all? { |r| r.is_a?(described_class::Response) }).to be_truthy
       end
     end


### PR DESCRIPTION
This commit does four things:

1. Enables the export of Categorization.  Without the `self.export_as_xml = true` setting when we won't export the    Categorization questions ([see code][1])
2. Re-organizes the module and class attribute declarations for more visual unity; this helps organize the class attributes for quicker scanning.
3. Reworks a fixture to not use an opaque question but demonstrate a more obvious pair of questions and answers.
4. Adds tests to ensure that we are setting the choices; without the `choices << Choice.new` in `app/models/concerns/matching_question_behavior.rb` we had no valid choices rendered in our XML.

[1]: https://github.com/scientist-softserv/viva/blob/62ebdd1/app/views/search/index.xml.erb#L12
