### PR TITLE
🎁 Add export of Upload and Essay

### DIFF
--- a/app/models/concerns/markdown_question_behavior.rb
+++ b/app/models/concerns/markdown_question_behavior.rb
@@ -13,6 +13,7 @@ module MarkdownQuestionBehavior
     validates :data, presence: true
   end
 
+  DATA_KEY_NAME = 'html'
   class ImportCsvRow < Question::ImportCsvRow
     # rubocop:disable Metrics/MethodLength
 
@@ -51,12 +52,22 @@ module MarkdownQuestionBehavior
       # nor transport.
       html = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(@text).delete("\n")
 
-      @data = { "html" => html }
+      @data = { DATA_KEY_NAME => html }
     end
     # rubocop:enable Metrics/MethodLength
 
     def validate_well_formed_row
       errors.add(:base, "expected one or more TEXT columns") unless row.key?("TEXT") || @section_integers.any?
     end
+  end
+
+  ##
+  # @return [NilClass] when we have not yet set the data.
+  # @return [String] HTML unsafe content (e.g. raw HTML that has not been verified as safe nor
+  #         escaped.)
+  # @raise [KeyError] when the data does not have an 'html' key.  This is indicative of a disconnect
+  #        in the mapping of the imported data to the serialized form.
+  def html
+    data&.fetch(DATA_KEY_NAME)
   end
 end

--- a/app/models/question/essay.rb
+++ b/app/models/question/essay.rb
@@ -6,9 +6,11 @@
 # @note the {#data} attribute will be a Hash with one key: "html".  That "html" will be safe to
 #       render in the UI.
 class Question::Essay < Question
-  self.type_name = "Essay"
-
   include MarkdownQuestionBehavior
+
+  self.type_name = "Essay"
+  self.export_as_xml = true
+
   class ImportCsvRow < MarkdownQuestionBehavior::ImportCsvRow
   end
 end

--- a/app/models/question/upload.rb
+++ b/app/models/question/upload.rb
@@ -7,9 +7,11 @@
 # @note the {#data} attribute will be a Hash with one key: "html".  That "html" will be safe to
 #       render in the UI.
 class Question::Upload < Question
-  self.type_name = "Upload"
-
   include MarkdownQuestionBehavior
+
+  self.type_name = "Upload"
+  self.export_as_xml = true
+
   class ImportCsvRow < MarkdownQuestionBehavior::ImportCsvRow
   end
 end

--- a/app/views/question/essays/_essay.xml.erb
+++ b/app/views/question/essays/_essay.xml.erb
@@ -1,0 +1,36 @@
+<item ident="<%= essay.item_ident %>" title="Question <%= essay.id %>" >
+  <itemmetadata>
+    <qtimetadatafield>
+      <fieldlabel>question_type</fieldlabel>
+      <fieldentry>essay_question</fieldentry>
+    </qtimetadatafield>
+    <qtimetadatafield>
+      <fieldlabel>points_possible</fieldlabel>
+      <fieldentry>5</fieldentry>
+    </qtimetadatafield>
+    <qtimetadatafield>
+      <fieldlabel>assessment_question_identifierref</fieldlabel>
+      <fieldentry><%= essay.assessment_question_identifierref %></fieldentry>
+    </qtimetadatafield>
+  </itemmetadata>
+  <presentation>
+    <material>
+      <mattext texttype="text/html"><%= essay.html %></mattext>
+    </material>
+    <response_str ident="<%= essay.item_ident %>_response" rcardinality="Single" rce="Yes" word_count="No" spell_check="No" word_limit_enabled="No">
+      <render_fib>
+        <response_label ident="<%= essay.item_ident %>_answer" rshuffle="No"/>
+      </render_fib>
+    </response_str>
+  </presentation>
+  <resprocessing>
+    <outcomes>
+      <decvar maxvalue="<%= essay.qti_max_value %>" minvalue="0" varname="SCORE" vartype="Decimal"/>
+    </outcomes>
+    <respcondition continue="No">
+      <conditionvar>
+        <other/>
+      </conditionvar>
+    </respcondition>
+  </resprocessing>
+</item>

--- a/app/views/question/uploads/_upload.xml.erb
+++ b/app/views/question/uploads/_upload.xml.erb
@@ -1,0 +1,36 @@
+<item ident="<%= upload.item_ident %>" title="Question <%= upload.id %>" >
+  <itemmetadata>
+    <qtimetadatafield>
+      <fieldlabel>question_type</fieldlabel>
+      <fieldentry>essay_question</fieldentry>
+    </qtimetadatafield>
+    <qtimetadatafield>
+      <fieldlabel>points_possible</fieldlabel>
+      <fieldentry>5</fieldentry>
+    </qtimetadatafield>
+    <qtimetadatafield>
+      <fieldlabel>assessment_question_identifierref</fieldlabel>
+      <fieldentry><%= upload.assessment_question_identifierref %></fieldentry>
+    </qtimetadatafield>
+  </itemmetadata>
+  <presentation>
+    <material>
+      <mattext texttype="text/html"><%= upload.html %></mattext>
+    </material>
+    <response_str ident="<%= upload.item_ident %>_response" rcardinality="Single" rce="Yes" word_count="No" spell_check="No" word_limit_enabled="No">
+      <render_fib>
+        <response_label ident="<%= upload.item_ident %>_answer" rshuffle="No"/>
+      </render_fib>
+    </response_str>
+  </presentation>
+  <resprocessing>
+    <outcomes>
+      <decvar maxvalue="<%= upload.qti_max_value %>" minvalue="0" varname="SCORE" vartype="Decimal"/>
+    </outcomes>
+    <respcondition continue="No">
+      <conditionvar>
+        <other/>
+      </conditionvar>
+    </respcondition>
+  </resprocessing>
+</item>

--- a/spec/models/question/essay_spec.rb
+++ b/spec/models/question/essay_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Question::Essay do
-  it_behaves_like "a Question"
+  it_behaves_like "a Question", export_as_xml: true
   it_behaves_like "a Markdown Question"
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Essay") }

--- a/spec/models/question/upload_spec.rb
+++ b/spec/models/question/upload_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Question::Upload do
-  it_behaves_like "a Question"
+  it_behaves_like "a Question", export_as_xml: true
   it_behaves_like "a Markdown Question"
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Upload") }

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -201,6 +201,26 @@ RSpec.shared_examples 'a Matching Question' do
 end
 
 RSpec.shared_examples 'a Markdown Question' do
+  describe '#html' do
+    context 'with no data' do
+      subject { described_class.new.html }
+      it { is_expected.to be_nil }
+    end
+
+    context 'with well formed data' do
+      subject { FactoryBot.build("question_#{described_class.name.demodulize.underscore}").html }
+      it { is_expected.to start_with("<") }
+    end
+
+    context 'with ill-formed data' do
+      subject { FactoryBot.build("question_#{described_class.name.demodulize.underscore}", data: { "not-html" => "Hello" }).html }
+
+      it 'raises a KeyError' do
+        expect { subject }.to raise_error(KeyError)
+      end
+    end
+  end
+
   describe '.build_row' do
     subject { described_class.build_row(row:, questions: {}) }
     context 'with invalid data due to mismatched columns' do

--- a/spec/views/question/essays/_essay.xml.erb_spec.rb
+++ b/spec/views/question/essays/_essay.xml.erb_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'question/essays/_essay' do
+  let(:essay) { FactoryBot.build(:question_essay) }
+
+  it 'renders xml' do
+    render partial: "question/essays/essay", locals: { essay: }
+    expect(rendered).to include(%(<item ident="#{essay.item_ident}" title="Question #{essay.id}" >))
+    # This appears to be a hard-coded assumption
+    expect(rendered).to include(%(<fieldentry>essay_question</fieldentry>))
+
+    # We are providing HTML and want to ensure it is escaped
+    expect(rendered).to include(%(<mattext texttype="text/html">&lt;))
+  end
+end

--- a/spec/views/question/uploads/_upload.xml.erb_spec.rb
+++ b/spec/views/question/uploads/_upload.xml.erb_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'question/uploads/_upload' do
+  let(:upload) { FactoryBot.build(:question_upload) }
+
+  it 'renders xml' do
+    render partial: "question/uploads/upload", locals: { upload: }
+    expect(rendered).to include(%(<item ident="#{upload.item_ident}" title="Question #{upload.id}" >))
+
+    # Yes the format type is essay question; perhaps there's a nuance that means Upload and Essay
+    # are not identical; but this is what was requested so I'm assuming there's differences
+    # somewhere.
+    expect(rendered).to include(%(<fieldentry>essay_question</fieldentry>))
+
+    # We are providing HTML and want to ensure it is escaped
+    expect(rendered).to include(%(<mattext texttype="text/html">&lt;))
+  end
+end


### PR DESCRIPTION
From the examples I have, the `Question::Essay` and `Question::Upload` are identical.  The client requested these separate concerns, so we implemented accordingly.

Regardless, this PR adds the ability to export the Essay and Upload question types.

Related to:

- https://github.com/scientist-softserv/viva/issues/235
- https://github.com/scientist-softserv/viva/issues/234