### PR TITLE
💄 Favor lighter header bar and footer bar

### DIFF
--- a/app/javascript/components/ui/Footer/index.jsx
+++ b/app/javascript/components/ui/Footer/index.jsx
@@ -3,7 +3,7 @@ import { Container, Nav, Navbar } from 'react-bootstrap'
 
 const Footer = () => {
   return (
-    <Navbar expand='lg' className='bg-light-4 py-1 mt-auto'>
+    <Navbar expand='lg' className='bg-light-2 py-1 mt-auto'>
       <Container fluid>
         <Nav className='me-auto'>
           <Nav.Link href='/'>Home</Nav.Link>

--- a/app/javascript/components/ui/Header/index.jsx
+++ b/app/javascript/components/ui/Header/index.jsx
@@ -4,7 +4,7 @@ import Logo from '../../../../assets/images/logotransparent.png'
 
 const Header = () => {
   return (
-    <Container fluid className='bg-light-4 py-1'>
+    <Container fluid className='bg-light-2 py-1'>
       <Navbar.Brand href='/'>
         <Image src={Logo} height='60'/>
       </Navbar.Brand>


### PR DESCRIPTION
The `bg-light-4` class creates too low of contrast for both the blue and
grey text in the header and footer.  By shifting to `bg-light-2` we
improve the color contrast.

In the below image, the lighter container color is on the left and the original is on the right.

<img width="1707" alt="Screenshot 2024-03-28 at 10 39 42 AM" src="https://github.com/scientist-softserv/viva/assets/2130/e2b7c37a-9320-4499-95f7-9de0357ff992">


Related to:

- https://github.com/scientist-softserv/viva/issues/260