### PR TITLE
🎁 Users can upload ZIP files

### DIFF
--- a/app/javascript/components/pages/Uploads/index.jsx
+++ b/app/javascript/components/pages/Uploads/index.jsx
@@ -20,12 +20,12 @@ const Uploads = (props) => {
     let fileName = data.csv && data.csv[0].name
     e.preventDefault()
     if (fileName.length === 0) {
-      setError('csv', 'Please select a CSV to upload.')
+      setError('csv', 'Please select a CSV or ZIP to upload.')
       setTimeout(() => {
         clearErrors()
       }, 3000)
-    } else if (fileName.slice(-3) !== 'csv') {
-      setError('csv', 'Please select a file with a CSV extension.')
+    } else if (fileName.slice(-3) !== 'csv' && fileName.slice(-3) !== 'zip') {
+      setError('csv', 'Please select a file with a CSV or ZIP extension.')
       setTimeout(() => {
         clearErrors()
       }, 3000)
@@ -64,7 +64,7 @@ const Uploads = (props) => {
         <UploadForm submit={submit} setData={setData} processing={processing} />
         {recentlySuccessful &&
           <div className='alert alert-success'>
-            Your CSV has been uploaded successfully!
+            Your file has been uploaded successfully!
           </div>
         }
         {(errors.csv || (responseErrors && Object.keys(responseErrors).length > 0)) &&

--- a/app/javascript/components/ui/UploadForm/UploadForm.jsx
+++ b/app/javascript/components/ui/UploadForm/UploadForm.jsx
@@ -7,7 +7,7 @@ const UploadForm = ({ submit, setData, processing }) => {
     <Form onSubmit={submit} className='csv-upload-form text-uppercase'>
       <InputGroup className='mb-3'>
         <InputGroup.Text className='strait py-3'>
-              Select a CSV to Upload
+              Select a CSV or ZIP to Upload
         </InputGroup.Text>
         <Form.Group controlId='upload-csv'>
           <Form.Control
@@ -16,7 +16,7 @@ const UploadForm = ({ submit, setData, processing }) => {
             onChange={e => setData('csv', e.target.files)}
             className='rounded-0 py-3'
             multiple={false}
-            accept='.csv'
+            accept='.csv, .zip'
           />
         </Form.Group>
         <Button


### PR DESCRIPTION
# Story

Update the UploadForm component to accept zip files in addition to csv files.

Refs

- [#276](https://github.com/scientist-softserv/viva/issues/276)

# Expected Behavior Before Changes

Users were prevented from uploading a file with a zip extension.

# Expected Behavior After Changes

Users are able to upload zip files as well as csv files. Language on the upload button and flash message changed accordingly.

# Screenshots / Video

https://github.com/user-attachments/assets/9590801e-f1fb-4605-928c-6781ebb7c3b9