### PR TITLE
🎁 View all bookmarks

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -94,7 +94,9 @@ class SearchController < ApplicationController
       subjects: params[:selected_subjects],
       type_name: params[:selected_types],
       levels: params[:selected_levels],
-      bookmarked_question_ids: params[:bookmarked_question_ids]
+      bookmarked_question_ids: params[:bookmarked_question_ids],
+      bookmarked: ActiveModel::Type::Boolean.new.cast(params[:bookmarked]),
+      user: current_user
     }
   end
 end

--- a/app/javascript/components/ui/Search/SearchBar.jsx
+++ b/app/javascript/components/ui/Search/SearchBar.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import {
-  InputGroup, DropdownButton, Button, Container, Form, Dropdown
+  InputGroup, DropdownButton, Button, Container, Form
 } from 'react-bootstrap'
 import { MagnifyingGlass } from '@phosphor-icons/react'
 import CustomDropdown from '../../ui/CustomDropdown'
@@ -39,12 +39,6 @@ const SearchBar = (props) => {
     })
   }
 
-  const handleExportBookmarks = () => {
-    const queryString = bookmarkedQuestionIds.map(id => `bookmarked_question_ids[]=${encodeURIComponent(id)}`).join('&')
-    const url = `/.xml?${queryString}`
-    window.location.href = url
-  }
-
   return (
     <Form onSubmit={submit}>
       <Container className='p-0 mt-2 search-bar'>
@@ -81,28 +75,37 @@ const SearchBar = (props) => {
           <CustomDropdown key='bookmark' dropdownSelector='.dropdown-toggle'>
             <DropdownButton
               variant='outline-light-4 text-black fs-6 d-flex align-items-center justify-content-between'
-              title='Bookmarks'
+              title={`Bookmarks (${bookmarkedQuestionIds.length})`}
               id='input-group-dropdown-bookmark'
               size='lg'
               autoClose='outside'
             >
-              <Button
-                variant='primary'
-                className='p-2 m-2 mt-3'
-                onClick={handleExportBookmarks}
-                disabled={!hasBookmarks}
-              >
-                Export {bookmarkedQuestionIds.length > 0 ? bookmarkedQuestionIds.length : ''} Bookmark{bookmarkedQuestionIds.length > 1 || bookmarkedQuestionIds.length === 0 ? 's' : ''}
-              </Button>
-              <Dropdown.Divider />
-              <Button
-                variant='danger'
-                className='p-2 m-2 mb-3'
-                onClick={handleDeleteAllBookmarks}
-                disabled={!hasBookmarks}
-              >
-                Clear Bookmarks
-              </Button>
+              <div className='d-flex flex-column align-items-start'>
+                <a
+                  href='?bookmarked=true'
+                  className={`btn btn-primary p-2 m-2 ${!hasBookmarks ? 'disabled' : ''}`}
+                  role='button'
+                  aria-disabled={!hasBookmarks}
+                >
+                  View Bookmarks
+                </a>
+                <a
+                  href={`/.xml?${bookmarkedQuestionIds.map(id => `bookmarked_question_ids[]=${encodeURIComponent(id)}`).join('&')}`}
+                  className={`btn btn-primary p-2 m-2 ${!hasBookmarks ? 'disabled' : ''}`}
+                  role='button'
+                  aria-disabled={!hasBookmarks}
+                >
+                  Export Bookmarks
+                </a>
+                <Button
+                  variant='danger'
+                  className='p-2 m-2'
+                  onClick={handleDeleteAllBookmarks}
+                  disabled={!hasBookmarks}
+                >
+                  Clear Bookmarks
+                </Button>
+              </div>
             </DropdownButton>
           </CustomDropdown>
           <Button

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -443,7 +443,7 @@ class Question < ApplicationRecord
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/ParameterLists
-  def self.filter(keywords: [], subjects: [], levels: [], bookmarked_question_ids: [], type_name: nil, select: nil)
+  def self.filter(keywords: [], subjects: [], levels: [], bookmarked_question_ids: [], bookmarked: nil, type_name: nil, select: nil, user: nil)
     # By wrapping in an array we ensure that our keywords.size and subjects.size are counting
     # the number of keywords given and not the number of characters in a singular keyword that was
     # provided.
@@ -488,6 +488,8 @@ class Question < ApplicationRecord
     end
 
     questions = Question.where(id: bookmarked_question_ids) if bookmarked_question_ids.present?
+
+    questions = user.bookmarked_questions if bookmarked
 
     return questions if select.blank?
 


### PR DESCRIPTION
# Story

This commit will add a way for the user to view all the bookmarked questions.  My reasoning for the mix of a tags and button element is because the first two buttons in the bookmarks dropdown should be anchor tags since they are navigation elements and the third button, which is the delete all bookmarks button, should stay a button because it is an action element.

Ref:
  - https://github.com/scientist-softserv/viva/issues/281

# Expected Behavior Before Changes

The user was not able to see all of their bookmarks in one convenient view.

# Expected Behavior After Changes

The user now can see all the bookmarks in one convenient view.

# Screenshots / Video

https://github.com/user-attachments/assets/1d466ea7-589a-4c81-a9eb-87ead04fc1c0
