### PR TITLE
🐛 Subject and Keyword duplication bug

### DIFF
--- a/app/javascript/components/ui/CreateQuestionForm/Keyword.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Keyword.jsx
@@ -11,7 +11,8 @@ const Keyword = ({ keywords, handleAddKeyword, handleRemoveKeyword }) => {
 
   const submitKeyword = () => {
     const trimmedKeyword = keyword.trim()
-    if (trimmedKeyword.toLowerCase() && !keywords.includes(trimmedKeyword.toLowerCase())) {
+    const normalizedKeyword = keywords.map(key => key.toLowerCase())
+    if (trimmedKeyword.toLowerCase() && !normalizedKeyword.includes(trimmedKeyword.toLowerCase())) {
       handleAddKeyword(trimmedKeyword)
       setKeyword('') // Clear input after adding
     } else {

--- a/app/javascript/components/ui/CreateQuestionForm/Subject.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Subject.jsx
@@ -11,7 +11,8 @@ const Subject = ({ subjects, handleAddSubject, handleRemoveSubject }) => {
 
   const submitSubject = () => {
     const trimmedSubject = subject.trim()
-    if (trimmedSubject.toLowerCase() && !subjects.includes(trimmedSubject.toLowerCase())) {
+    const normalizedSubject = subjects.map(sub => sub.toLowerCase())
+    if (trimmedSubject.toLowerCase() && !normalizedSubject.includes(trimmedSubject.toLowerCase())) {
       handleAddSubject(trimmedSubject)
       setSubject('') // Clear input after adding
     } else {


### PR DESCRIPTION
# Story: Keyword and Subject bug fix

Ref:
- https://github.com/notch8/viva/issues/297

## Expected Behavior Before Changes

There was a bug that allowed the user to add a Keyword or Subject with a capitalized letter then add the same word with a lowercase letter. As long as the capitalized word was added first, the code logic would allow the lowercase word to be added as well.

## Expected Behavior After Changes

No duplicate words, regardless of casing, should be permitted in the Keyword or Subject values. 

## Screenshots / Video

<details>
<summary>Bug</summary>

[image/video](https://github.com/user-attachments/assets/a2f19f81-a73b-43e5-913b-443ff3ab29d5)

</details>

<details>
<summary>Fixed</summary>

https://github.com/user-attachments/assets/08b147e1-55b8-40e4-87d7-5ce59162bd69


</details>

