### PR TITLE
🐛 Disables removal button on required inputs

### DIFF
--- a/app/javascript/components/ui/CreateQuestionForm/Categorization.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Categorization.jsx
@@ -75,7 +75,12 @@ const Categorization = ({ questionText, handleTextChange, onDataChange, resetFie
               onChange={(e) => updateCategory(index, 'answer', e.target.value)}
               className='me-2'
             />
-            <Button variant='danger' size='sm' onClick={() => removeCategory(index)}>
+            <Button
+              variant='danger'
+              size='sm'
+              onClick={() => removeCategory(index)}
+              disabled={categories.length === 1}
+            >
               Remove Category
             </Button>
           </div>
@@ -94,6 +99,7 @@ const Categorization = ({ questionText, handleTextChange, onDataChange, resetFie
                   variant='danger'
                   size='sm'
                   onClick={() => removeCorrectValue(index, subIndex)}
+                  disabled={category.correct.length === 1}
                 >
                   Remove
                 </Button>

--- a/app/javascript/components/ui/CreateQuestionForm/Matching.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Matching.jsx
@@ -67,6 +67,7 @@ const Matching = ({ questionText, handleTextChange, onDataChange, resetFields })
               variant='danger'
               size='sm'
               onClick={() => removePair(index)}
+              disabled={pairs.length === 1}
             >
               Remove
             </Button>


### PR DESCRIPTION
# Story: Disables removal button on required inputs

Ref:
- https://github.com/notch8/viva/issues/298
- https://github.com/notch8/viva/issues/297

## Expected Behavior Before Changes

The user could remove all input forms on Categorization and Matching forms. This would enable the submit button and allow the user to attempt to create a question without all its data resulting in an error message.

## Expected Behavior After Changes

User cannot delete the min required inputs. Submit button is not enabled until data is valid.

## Screenshots / Video

<details>
<summary>Bug (Before)</summary>

https://github.com/user-attachments/assets/21c9cdf5-1ba5-4a99-a516-5151b0d7a1e5

</details>

<details>
<summary>Fix (After)</summary>

https://github.com/user-attachments/assets/8607f0df-ea00-479b-92e6-2cbccc0b081a

</details>

