### PR TITLE
🐛 Fixes console error occurring on form render

### DIFF
--- a/app/javascript/components/ui/CreateQuestionForm/AnswerField.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/AnswerField.jsx
@@ -16,7 +16,7 @@ const AnswerField = ({ answers, updateAnswer, removeAnswer, title, buttonType = 
           />
           <Form.Check
             type={buttonType}
-            checked={answer.correct}
+            defaultChecked={answer.correct}
             onClick={() => {
               if (buttonType === 'radio') {
                 if (answer.correct) {


### PR DESCRIPTION
# Story: [i330] Fixes console error occurring on form render

Ref:
- https://github.com/notch8/viva/issues/330

## Expected Behavior Before Changes

This commit fixes a console error that was occurring when a user selected the bowtie, drag and drop, mult choice, SATA - either as a regular question or a sub question to the case study question form.

## Expected Behavior After Changes

No errors occur in the console.

## Screenshots / Video

<details>
<summary>Console Error (Before)</summary>

![Screenshot 2025-01-07 at 3 35 34 PM](https://github.com/user-attachments/assets/dfefe1d3-99ae-4ec2-9bb1-d1eea3ad025f)

</details>