### PR TITLE
Update resource configuration to match deployment settings

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -14,11 +14,10 @@ web:
   replicaCount: 1
   resources:
     limits:
-      memory: "3Gi"
-      cpu: "400m"
+      memory: 8Gi
     requests:
-      memory: "1.5Gi"
-      cpu: "200m"
+      cpu: 250m
+      memory: 4Gi
 
 rails:
   image:


### PR DESCRIPTION
The client reported that staging was slow. This seems similar to the slowness Pals reported. Viva lives on the same cluster which has less nodes than it did before the rancher upgrade. When pairing with Rob, he adjusted Pals' resource limits to help with its performance. These updates matches the updates we made for pals. 

- Set memory limits to 8192Mi as specified in the Rancher deployment.
- Adjust memory requests to 4096Mi to align with the deployment settings.
- Set CPU requests to 250m based on the specified CPU reservation in the Rancher interface.
- Removed CPU limit as it was not defined in the deployment settings.

These changes ensure the resource definitions are consistent with the Rancher configuration.

When pairing with Rob, Pals was live updated to: 

![Screenshot 2025-01-21 at 16-55-49 Rancher - r2-staging - palni-palci-knapsack-staging-hyrax](https://github.com/user-attachments/assets/a4694150-1136-48c4-81d2-1e3cf65ae1c9)
