### PR TITLE
:bug: simplify ids for Matching allows us to upload into Canvas successfully

### DIFF
--- a/spec/models/concerns/matching_question_behavior_spec.rb
+++ b/spec/models/concerns/matching_question_behavior_spec.rb
@@ -34,11 +34,8 @@ RSpec.describe MatchingQuestionBehavior do
         instance.send(:build_qti_data)
         conditions = instance.qti_response_conditions
 
-        # Check response identifiers follow expected pattern
-        expect(conditions[0].response.ident).to eq('response_1000')
-        expect(conditions[1].response.ident).to eq('response_2000')
+        expect(conditions[0].response.ident).not_to eq(conditions[1].response.ident)
 
-        # Get all choice identifiers
         choice_idents = conditions.flat_map { |c| c.choices.map(&:ident) }
 
         # Verify all identifiers are unique
@@ -61,20 +58,13 @@ RSpec.describe MatchingQuestionBehavior do
         instance.send(:build_qti_data)
         conditions = instance.qti_response_conditions
 
-        # First matching pair should have two 'A' choices
         expect(conditions[0].choices.map(&:text)).to eq(['A', 'A'])
-
-        # Second matching pair should have 'B' and 'A'
         expect(conditions[1].choices.map(&:text)).to eq(['B', 'A'])
       end
 
       it 'generates numeric identifiers in expected ranges' do
         instance.send(:build_qti_data)
         conditions = instance.qti_response_conditions
-
-        # Response IDs should be multiples of 1000
-        response_idents = conditions.map { |c| c.response.ident }
-        expect(response_idents).to eq(['response_1000', 'response_2000'])
 
         # Choice IDs should be sequential numbers starting from 100
         choice_idents = conditions.flat_map { |c| c.choices.map(&:ident) }.map(&:to_i)
@@ -96,7 +86,7 @@ RSpec.describe MatchingQuestionBehavior do
         conditions = instance.qti_response_conditions
 
         choice_idents = conditions.flat_map { |c| c.choices.map(&:ident) }.map(&:to_i)
-        expect(choice_idents).to eq((100..103).to_a)
+        expect(choice_idents.each_cons(2).all? { |a, b| b == a + 1 }).to be_truthy
       end
     end
   end

--- a/spec/models/concerns/matching_question_behavior_spec.rb
+++ b/spec/models/concerns/matching_question_behavior_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MatchingQuestionBehavior do
+  before(:all) do
+    # Create a temporary class that includes our behavior
+    class TestMatchingQuestion < ApplicationRecord
+      self.table_name = 'questions' # Use the questions table
+      include MatchingQuestionBehavior
+
+      def qti_max_value
+        100
+      end
+    end
+  end
+
+  after(:all) do
+    # Clean up our temporary class
+    Object.send(:remove_const, :TestMatchingQuestion)
+  end
+
+  describe '#build_qti_data' do
+    let(:instance) { TestMatchingQuestion.new }
+
+    context 'with duplicate choice text' do
+      before do
+        instance.data = [
+          { 'answer' => 'Match 1', 'correct' => ['A', 'A'] },  # Intentionally duplicate
+          { 'answer' => 'Match 2', 'correct' => ['B', 'A'] }   # 'A' appears again
+        ]
+      end
+
+      it 'generates unique identifiers even for duplicate choice text' do
+        instance.send(:build_qti_data)
+        conditions = instance.qti_response_conditions
+
+        # Check response identifiers follow expected pattern
+        expect(conditions[0].response.ident).to eq('response_1000')
+        expect(conditions[1].response.ident).to eq('response_2000')
+
+        # Get all choice identifiers
+        choice_idents = conditions.flat_map { |c| c.choices.map(&:ident) }
+
+        # Verify all identifiers are unique
+        expect(choice_idents.uniq).to eq(choice_idents)
+
+        # Verify format of choice identifiers
+        expect(choice_idents).to all(match(/^\d+$/))
+
+        # Get all 'A' choices and their identifiers
+        a_idents = conditions.flat_map do |condition|
+          condition.choices.select { |c| c.text == 'A' }.map(&:ident)
+        end
+
+        # We should have 3 'A's with unique identifiers
+        expect(a_idents.length).to eq(3)
+        expect(a_idents.uniq.length).to eq(3)
+      end
+
+      it 'maintains correct text associations despite unique identifiers' do
+        instance.send(:build_qti_data)
+        conditions = instance.qti_response_conditions
+
+        # First matching pair should have two 'A' choices
+        expect(conditions[0].choices.map(&:text)).to eq(['A', 'A'])
+
+        # Second matching pair should have 'B' and 'A'
+        expect(conditions[1].choices.map(&:text)).to eq(['B', 'A'])
+      end
+
+      it 'generates numeric identifiers in expected ranges' do
+        instance.send(:build_qti_data)
+        conditions = instance.qti_response_conditions
+
+        # Response IDs should be multiples of 1000
+        response_idents = conditions.map { |c| c.response.ident }
+        expect(response_idents).to eq(['response_1000', 'response_2000'])
+
+        # Choice IDs should be sequential numbers starting from 100
+        choice_idents = conditions.flat_map { |c| c.choices.map(&:ident) }.map(&:to_i)
+        expect(choice_idents.min).to be >= 100
+        expect(choice_idents).to eq(choice_idents.sort)
+      end
+    end
+
+    context 'with non-duplicate choices' do
+      before do
+        instance.data = [
+          { 'answer' => 'Match 1', 'correct' => ['A', 'B'] },
+          { 'answer' => 'Match 2', 'correct' => ['C', 'D'] }
+        ]
+      end
+
+      it 'still generates sequential identifiers' do
+        instance.send(:build_qti_data)
+        conditions = instance.qti_response_conditions
+
+        choice_idents = conditions.flat_map { |c| c.choices.map(&:ident) }.map(&:to_i)
+        expect(choice_idents).to eq((100..103).to_a)
+      end
+    end
+  end
+end

--- a/spec/views/question/matchings/_matching.xml.erb_spec.rb
+++ b/spec/views/question/matchings/_matching.xml.erb_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'question/matchings/_matching' do
   let(:matching) { FactoryBot.build(:question_matching) }
+  let(:another_matching) { FactoryBot.build(:question_matching) }
 
   it 'renders xml' do
     render partial: "question/matchings/matching", locals: { matching: }
@@ -12,5 +13,28 @@ RSpec.describe 'question/matchings/_matching' do
     # See https://github.com/notch8/viva/issues/237
     expect(rendered).not_to include(%(rcardinality="Multiple">))
     expect(rendered).to include(%(<fieldentry>matching_question</fieldentry>))
+  end
+
+  it 'generates unique identifiers for different questions' do
+    # Render first matching question
+    render partial: "question/matchings/matching", locals: { matching: }
+    first_rendered = rendered
+
+    # Extract response identifiers from first rendering
+    first_response_ids = first_rendered.scan(/response_lid ident="(response_\d+)"/).flatten
+
+    # Render second matching question
+    render partial: "question/matchings/matching", locals: { matching: another_matching }
+    second_rendered = rendered
+
+    # Extract response identifiers from second rendering
+    second_response_ids = second_rendered.scan(/response_lid ident="(response_\d+)"/).flatten
+
+    # Verify both questions have response identifiers
+    expect(first_response_ids).not_to be_empty
+    expect(second_response_ids).not_to be_empty
+
+    # Verify the identifiers are different between questions
+    expect(first_response_ids).not_to match_array(second_response_ids)
   end
 end


### PR DESCRIPTION
This is the results of a spike - 

Fix QTI export for Canvas matching questions to display all dropdown options

Related Issue:
- https://github.com/notch8/viva/issues/339

Previously, Canvas would only display a single option in dropdown menus for matching questions due to complex identifier strings. Changed identifier format to use simple numeric IDs (e.g. "100", "101") for choices and "response_1000" style IDs for responses.

Technical changes:
- Modified build_qti_data to generate simple numeric identifiers
- Added Set tracking to ensure uniqueness even with duplicate choice text
- Added tests to verify identifier uniqueness and formatting
- Added documentation explaining Canvas's undocumented identifier requirements

This change ensures all dropdown options are properly displayed in Canvas when importing QTI formatted matching questions.


This created export: questions-2025-02-06_19_50_55_619.classic-question-canvas.qti.xml.zip




## BEFORE 

<img width="641" alt="image" src="https://github.com/user-attachments/assets/477d18b2-7716-4ec9-b017-192a2b5b67c8" />

## AFTER

corresponding import example (previously each dropdown only showed one option and they were all the same): 
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/a0a33c4c-90c8-4f5b-9246-a89a64bbbffa" />

![image](https://github.com/user-attachments/assets/0336995b-efbf-4441-a8cc-ee5f7bac0988)


