### PR TITLE
I347 full text search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jbuilder' # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jquery-rails'
 gem 'jsbundling-rails' # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem 'pg', '~> 1.1' # Use postgresql as the database for Active Record
+gem 'pg_search'
 gem 'pry-byebug', group: %i[development test]
 gem 'puma', '~> 5.0' # Use the Puma web server [https://github.com/puma/puma]
 gem 'rails', '~> 7.0.5' # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pg_search (2.3.7)
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
     popper_js (2.11.8)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -381,6 +384,7 @@ DEPENDENCIES
   jquery-rails
   jsbundling-rails
   pg (~> 1.1)
+  pg_search
   pry-byebug
   puma (~> 5.0)
   rails (~> 7.0.5)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -70,7 +70,7 @@ class SearchController < ApplicationController
       selectedSubjects: params[:selected_subjects],
       selectedTypes: params[:selected_types],
       selectedLevels: params[:selected_levels],
-      filteredQuestions: Question.filter_as_json(**filter_values),
+      filteredQuestions: Question.filter_as_json(search: params[:search], **filter_values),
       exportHrefs: export_hrefs,
       bookmarkedQuestionIds: current_user.bookmarks.pluck(:question_id)
     }

--- a/app/javascript/components/ui/Search/SearchBar.jsx
+++ b/app/javascript/components/ui/Search/SearchBar.jsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react'
 import {
   InputGroup, DropdownButton, Button, Container, Form
 } from 'react-bootstrap'
-import { MagnifyingGlass } from '@phosphor-icons/react'
-import CustomDropdown from '../CustomDropdown'
+import { MagnifyingGlass, XCircle } from '@phosphor-icons/react'
 import { Inertia } from '@inertiajs/inertia'
 
 const SearchBar = (props) => {
@@ -12,21 +11,91 @@ const SearchBar = (props) => {
     keywords,
     types,
     levels,
-    submit,
-    handleFilters,
     processing,
     selectedKeywords,
     selectedTypes,
     selectedSubjects,
     selectedLevels,
-    bookmarkedQuestionIds
+    bookmarkedQuestionIds,
+    searchTerm
   } = props
+
   const filters = { subjects, keywords, types, levels }
+  const [query, setQuery] = useState(searchTerm || '')
+  const [filterState, setFilterState] = useState({
+    selectedKeywords: selectedKeywords || [],
+    selectedTypes: selectedTypes || [],
+    selectedSubjects: selectedSubjects || [],
+    selectedLevels: selectedLevels || []
+  })
   const [hasBookmarks, setHasBookmarks] = useState(bookmarkedQuestionIds.length > 0)
+
+  useEffect(() => {
+    if (searchTerm !== undefined && searchTerm !== query) {
+      setQuery(searchTerm)
+    }
+  }, [searchTerm])
 
   useEffect(() => {
     setHasBookmarks(bookmarkedQuestionIds.length > 0)
   }, [bookmarkedQuestionIds])
+
+  const handleSearchChange = (event) => {
+    setQuery(event.target.value)
+  }
+
+  const handleSearchSubmit = (event) => {
+    event.preventDefault()
+    console.log('Submitting with filters:', filterState)
+    Inertia.get(window.location.pathname, {
+      search: query,
+      selected_keywords: filterState.selectedKeywords,
+      selected_subjects: filterState.selectedSubjects,
+      selected_types: filterState.selectedTypes,
+      selected_levels: filterState.selectedLevels,
+    }, {
+      preserveState: true,
+      preserveScroll: true
+    })
+  }
+
+  const handleReset = () => {
+    setQuery('')
+    setFilterState({
+      selectedKeywords: [],
+      selectedTypes: [],
+      selectedSubjects: [],
+      selectedLevels: []
+    })
+    Inertia.get(window.location.pathname, {
+      search: '',
+      selected_keywords: [],
+      selected_subjects: [],
+      selected_types: [],
+      selected_levels: [],
+    }, {
+      preserveState: true,
+      preserveScroll: true
+    })
+  }
+
+  const handleFilterChange = (event, filterKey) => {
+    const { value, checked } = event.target
+    setFilterState((prevState) => {
+      const updatedFilters = [...prevState[filterKey]]
+
+      if (checked && !updatedFilters.includes(value)) {
+        updatedFilters.push(value)
+      } else if (!checked) {
+        const index = updatedFilters.indexOf(value)
+        if (index !== -1) {
+          updatedFilters.splice(index, 1)
+        }
+      }
+
+      return { ...prevState, [filterKey]: updatedFilters }
+    })
+  }
 
   const handleDeleteAllBookmarks = () => {
     Inertia.delete('/bookmarks/destroy_all', {
@@ -35,79 +104,23 @@ const SearchBar = (props) => {
       },
       onError: () => {
         console.error('Failed to clear all bookmarks')
-      },
+      }
     })
   }
 
   return (
-    <Form onSubmit={submit}>
+    <Form onSubmit={handleSearchSubmit}>
       <Container className='p-0 mt-2 search-bar'>
         <InputGroup className='mb-3 flex-column flex-md-row'>
-          {/* props being passed to this component are each of the filters. the keys are the name of the filter, and the values are the list of items to filter by */}
-          {Object.keys(filters).map((key, index) => (
-            <CustomDropdown key={index} dropdownSelector='.dropdown-toggle'>
-              <DropdownButton
-                variant='outline-light-4 text-black fs-6 d-flex align-items-center justify-content-between'
-                title={key}
-                id={`input-group-dropdown-${index}`}
-                size='lg'
-                autoClose='outside'
-              >
-                {filters[key].map((item, itemIndex) => (
-                  <Form.Check type='checkbox' id={item} className='p-2' key={itemIndex}>
-                    <Form.Check.Input
-                      type='checkbox'
-                      id={item}
-                      className='mx-0'
-                      value={item}
-                      onChange={(event) => handleFilters(event, key)}
-                      defaultChecked={selectedSubjects.includes(item) || selectedKeywords.includes(item) || selectedTypes.includes(item) || selectedLevels.includes(item)}
-                    />
-                    <Form.Check.Label className='ps-2'>
-                      {filters[key] === 'types' ? item.substring(10) : item}
-                    </Form.Check.Label>
-                  </Form.Check>
-                )
-                )}
-              </DropdownButton>
-            </CustomDropdown>
-          ))}
-          <CustomDropdown key='bookmark' dropdownSelector='.dropdown-toggle'>
-            <DropdownButton
-              variant='outline-light-4 text-black fs-6 d-flex align-items-center justify-content-between'
-              title={`Bookmarks (${bookmarkedQuestionIds.length})`}
-              id='input-group-dropdown-bookmark'
-              size='lg'
-              autoClose='outside'
-            >
-              <div className='d-flex flex-column align-items-start'>
-                <a
-                  href='?bookmarked=true'
-                  className={`btn btn-primary p-2 m-2 ${!hasBookmarks ? 'disabled' : ''}`}
-                  role='button'
-                  aria-disabled={!hasBookmarks}
-                >
-                  View Bookmarks
-                </a>
-                <a
-                  href={`/.xml?${bookmarkedQuestionIds.map(id => `bookmarked_question_ids[]=${encodeURIComponent(id)}`).join('&')}`}
-                  className={`btn btn-primary p-2 m-2 ${!hasBookmarks ? 'disabled' : ''}`}
-                  role='button'
-                  aria-disabled={!hasBookmarks}
-                >
-                  Export Bookmarks
-                </a>
-                <Button
-                  variant='danger'
-                  className='p-2 m-2'
-                  onClick={handleDeleteAllBookmarks}
-                  disabled={!hasBookmarks}
-                >
-                  Clear Bookmarks
-                </Button>
-              </div>
-            </DropdownButton>
-          </CustomDropdown>
+          {/* Search Input */}
+          <Form.Control
+            type='text'
+            name='search'
+            placeholder='search questions...'
+            value={query}
+            onChange={handleSearchChange}
+            className='border border-light-4 text-black'
+          />
           <Button
             className='d-flex align-items-center fs-6 justify-content-center'
             id='button-addon2'
@@ -116,8 +129,88 @@ const SearchBar = (props) => {
             disabled={processing}
           >
             <span className='me-1'>Search</span>
-            <MagnifyingGlass size={20} weight='bold'/>
+            <MagnifyingGlass size={20} weight='bold' />
           </Button>
+          {query && (
+            <Button
+              variant='outline-secondary'
+              className='d-flex align-items-center fs-6 justify-content-center ms-2'
+              size='lg'
+              onClick={handleReset}
+            >
+              <span className='me-1'>Reset</span>
+              <XCircle size={20} weight='bold' />
+            </Button>
+          )}
+        </InputGroup>
+
+        {/* Filters */}
+        <InputGroup className='mb-3 flex-column flex-md-row'>
+          {Object.keys(filters).map((key, index) => (
+            <DropdownButton
+              variant='outline-light-4 text-black fs-6 d-flex align-items-center justify-content-between'
+              title={key.toUpperCase()}
+              id={`input-group-dropdown-${index}`}
+              size='lg'
+              autoClose='outside'
+              key={index}
+            >
+              {filters[key].map((item, itemIndex) => (
+                <Form.Check
+                  type='checkbox'
+                  id={item}
+                  className='p-2'
+                  key={itemIndex}
+                >
+                  <Form.Check.Input
+                    type='checkbox'
+                    id={item}
+                    className='mx-0'
+                    value={item}
+                    onChange={(event) => handleFilterChange(event, `selected${key.charAt(0).toUpperCase() + key.slice(1)}`)}
+                    checked={filterState[`selected${key.charAt(0).toUpperCase() + key.slice(1)}`].includes(item)}
+                  />
+                  <Form.Check.Label className='ps-2'>{item}</Form.Check.Label>
+                </Form.Check>
+              ))}
+            </DropdownButton>
+          ))}
+
+          {/* Bookmarks */}
+          <DropdownButton
+            variant='outline-light-4 text-black fs-6 d-flex align-items-center justify-content-between'
+            title={`BOOKMARKS (${bookmarkedQuestionIds.length})`}
+            id='input-group-dropdown-bookmark'
+            size='lg'
+            autoClose='outside'
+          >
+            <div className='d-flex flex-column align-items-start'>
+              <a
+                href='?bookmarked=true'
+                className={`btn btn-primary p-2 m-2 ${!hasBookmarks ? 'disabled' : ''}`}
+                role='button'
+                aria-disabled={!hasBookmarks}
+              >
+                View Bookmarks
+              </a>
+              <a
+                href={'.xml?bookmarked=true'}
+                className={`btn btn-primary p-2 m-2 ${!hasBookmarks ? 'disabled' : ''}`}
+                role='button'
+                aria-disabled={!hasBookmarks}
+              >
+                Export Bookmarks
+              </a>
+              <Button
+                variant='danger'
+                className='p-2 m-2'
+                onClick={handleDeleteAllBookmarks}
+                disabled={!hasBookmarks}
+              >
+                Clear Bookmarks
+              </Button>
+            </div>
+          </DropdownButton>
         </InputGroup>
       </Container>
     </Form>

--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -48,4 +48,18 @@ class Question::StimulusCaseStudy < Question
       hash
     end
   end
+
+  private
+
+  def index_searchable_field
+    return if child_questions.empty?
+
+    texts = child_questions.map(&:text)
+    child_data = child_questions.map do |question|
+      question.send(:index_searchable_field)
+    end
+
+    combined_text = (texts + child_data).join(' ').squeeze(' ')
+    self.searchable = final_scrub(combined_text)
+  end
 end

--- a/db/migrate/20250225130500_add_searchable_to_questions.rb
+++ b/db/migrate/20250225130500_add_searchable_to_questions.rb
@@ -1,0 +1,14 @@
+class AddSearchableToQuestions < ActiveRecord::Migration[7.0]
+  def up
+    add_column :questions, :searchable, :tsvector
+    add_index :questions, :searchable, using: 'gin'
+
+    # Initialize the search vector for existing records
+    Question.find_each(&:save)
+  end
+
+  def down
+    remove_index :questions, :searchable
+    remove_column :questions, :searchable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_16_170855) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_25_130500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_16_170855) do
     t.datetime "updated_at", null: false
     t.text "data"
     t.string "level"
+    t.tsvector "searchable"
+    t.index ["searchable"], name: "index_questions_on_searchable", using: :gin
     t.index ["type"], name: "index_questions_on_type"
   end
 


### PR DESCRIPTION
# ⚠️ This requires a migration and saving all the files to update the records. `Question.find_each { |q| q.save! }` ⚠️

## 🚧 Install pg_search

646772b97279f50ff8b4cf83d292cd29c951f131

Following a thoughtbot article to add full text searching.

Ref:
- https://thoughtbot.com/blog/optimizing-full-text-search-with-postgres-tsvector-columns-and-triggers

## 🚧 Add searchable field to question

4ad63c22e7ce86ac258dac9f757baa4fbf713639

In this commit, we need to have a new column on the questions table and
index it so we can set the backend up for full text search.

## 🎁 Add logic to the Question model for pg_search

184f1ad898d1c0aa80550d9a003999db0d26e673

This commit will add logic to the Question model to make the pg_search
gem work.  We have the new `searchable` field which we are indexing the
`text` and `data` field words onto it.  We had to pay special
consideration for HTML strings and also specifically how it would work
with the StimulusCaseStudy question.  For that, we want to index all of
its child works' texts and data onto the `searchable` field.

## 🎁 Add search bar

e0c039ce1c63f24dd1380c714cb743c806319eaa

This commit will add a text input search bar for the SearchBar component
so the user can search for the text and data of the Question.

Ref:
- https://github.com/notch8/viva/issues/347

## Merge branch 'main' into i347-full-text-search

1b34603f1a146a99ffbed4a554f21b206bdece94


https://github.com/user-attachments/assets/92257360-9f09-4227-bec4-6697d9398d53
