### PR TITLE
Update homepage to Notch8

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
   <div class='row justify-content-center'>
     <div class = 'col-12 order-2 order-md-1 col-md-6 p-5 d-flex flex-column'>
       <h2 class='text-primary'>About Us</h2>
-      <p>COALA (Collection of Assignments and Learning Assessments) is an innovative repository prototype developed with support of an <a href="https://vivalib.org/va/open/IMLS-homework">IMLS National Leadership Planning Grant</a>, and in partnership with <a href="https://softserv.scientist.com">Software Services by Scientist.com</a> and the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a>. This platform offers educators an openly accessible hub for storing, searching, sharing, and assigning testing assessments linked with open educational resources.</p>
+      <p>COALA (Collection of Assignments and Learning Assessments) is an innovative repository prototype developed with support of an <a href="https://vivalib.org/va/open/IMLS-homework">IMLS National Leadership Planning Grant</a>, and in partnership with <a href="https://notch8.com">Notch8</a> and the <a href="https://rrchnm.org">Roy Rosenzweig Center for History and New Media</a>. This platform offers educators an openly accessible hub for storing, searching, sharing, and assigning testing assessments linked with open educational resources.</p>
     </div>
     <div class='col-12 col-md-6 p-5 order-1 order-md-2 bg-light rounded d-flex flex-column justify-content-between align-items-center'>
       <h2 class='align-self-start text-primary'>Log in</h2>


### PR DESCRIPTION
Updates the homepage text and link to Notch8 (the Notch8 url still redirects to the softserve site).

![Screenshot 2025-02-27 at 8 13 26 PM](https://github.com/user-attachments/assets/e5dce296-ee67-41d6-ac75-a341c4ebe5a3)
