### PR TITLE
🧹 Update seeds to use SubjectImporter

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,20 +47,8 @@ Question.destroy_all
 #   end
 # end
 
-nursing_question_subjects = [
-  "Nursing Process",
-  "Patient Education",
-  "Health Assessment",
-  "Pathophysiology",
-  "Medical Ethics",
-  "Healthcare Informatics",
-  "Cultural Competence"
-]
-
-subjects = nursing_question_subjects.map do |subject_name|
-  Subject.find_or_create_by(name: subject_name)
-end
-
+SubjectImporter.import
+subjects = Subject.all
 questions = []
 
 upload_question_1_data = {


### PR DESCRIPTION
This commit will update the seeds file to use the actual subjects as prescribed by the config/subjects.yaml which uses the SubjectImporter to load.

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/fa7fe927-1325-4da0-a67c-55bb1df44a02" />
