### PR TITLE
Handle subject importer error & add specs

### DIFF
--- a/app/services/subject_importer.rb
+++ b/app/services/subject_importer.rb
@@ -8,7 +8,7 @@ class SubjectImporter
     subjects = subjects_data['subjects']['name']
 
     subjects.each do |subject_name|
-      Subject.find_or_create_by(name: subject_name)
+      Subject.find_or_create_by(name: subject_name.downcase)
     end
   end
 end

--- a/spec/fixtures/files/subjects_to_import.yaml
+++ b/spec/fixtures/files/subjects_to_import.yaml
@@ -1,0 +1,6 @@
+subjects:
+  name:
+    - 'cow'
+    - 'dog'
+    - 'Dog'
+    - 'Cat'

--- a/spec/services/subject_importer_spec.rb
+++ b/spec/services/subject_importer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubjectImporter do
+  let(:subject) { described_class.import('spec/fixtures/files/subjects_to_import.yaml') }
+  let(:setting_names_array) do
+    subjects_data = YAML.load_file('spec/fixtures/files/subjects_to_import.yaml')
+    subjects_data['subjects']['name'].map(&:downcase).uniq
+  end
+
+  it 'creates subjects all in lower case' do
+    expect { subject }.to change(Subject, :count).by(setting_names_array.size)
+    expect(Subject.pluck(:name)).to match_array(setting_names_array)
+  end
+
+  describe 'does not create duplicate subjects' do
+    before do
+      subject
+    end
+    it 'does not create duplicate subjects' do
+      expect { subject }.not_to change(Subject, :count)
+    end
+  end
+end


### PR DESCRIPTION
Previously the subject importer would fail on a re-run, because the yaml was mixed case, and the records were created in all downcase. This resulted in `find_or_create` not finding the record, but the create failing due to a duplicate name. 

This patch fixes the subject importer and adds specs which verify it works.