### PR TITLE
🐛 fix Stimulus Case Study sub-questions' images

### DIFF
--- a/app/javascript/components/ui/Answers/StimulusCaseStudyAnswers.jsx
+++ b/app/javascript/components/ui/Answers/StimulusCaseStudyAnswers.jsx
@@ -8,7 +8,7 @@ const StimulusCaseStudyAnswers = ({ answers }) => {
       {answers.map((answer, index) => {
         return (
           <React.Fragment key={index}>
-            <Question text={answer.text} title={answer.type_label} />
+            <Question text={answer.text} title={answer.type_label} images={answer.images} />
             {answer.data && (
               <Answers
                 question_type_name={answer.type_name}

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -118,6 +118,12 @@ class Question < ApplicationRecord
     images.pluck(:alt_text)
   end
 
+  def images_as_json
+    images.map do |image|
+      { url: image.url, alt_text: image.alt_text }
+    end
+  end
+
   ##
   # {Question#type} is a partially reserved value; used for the Single Table Inheritance.  It is not
   # human friendly.  The {.type_names} is an effort to be more friendly.
@@ -344,9 +350,7 @@ class Question < ApplicationRecord
       question_json = question.as_json(only:, methods:)
 
       if question.images.present?
-        question_json['images'] = question.images.map do |image|
-          { url: image.url, alt_text: image.alt_text }
-        end
+        question_json['images'] = question.images_as_json
       else
         question_json['images'] = []
         question_json['alt_texts'] = []

--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -34,8 +34,8 @@ class Question::StimulusCaseStudy < Question
   #       be to move the has_many relations to Question but that would expose those methods to other
   #       question types.
   #
-  # @return [Array<Hash<String, Object>>] each element will have "type_label", "type_name", and
-  #         "text".  When the child_question has no {#data} it will be omitted (as in a
+  # @return [Array<Hash<String, Object>>] each element will have "type_label", "type_name", "text", and
+  #         "images".  When the child_question has no {#data} it will be omitted (as in a
   #         {Question::Scenario}).  When the child_question's data is present, it will conform to
   #         that question's {#data} structure (often an Array but could be a Hash).
   def data
@@ -43,7 +43,8 @@ class Question::StimulusCaseStudy < Question
       hash = {
         "type_label" => question.type_label,
         "type_name" => question.type_name,
-        "text" => question.text
+        "text" => question.text,
+        "images" => question.images_as_json
       }
       hash["data"] = question.data if question.data.present?
       hash

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe Question::StimulusCaseStudy do
       expect(subject.all? { |d| d.is_a?(Hash) }).to eq(true)
 
       # Making an assumption about the factory; namely that the first element is a scenario.
-      expect(subject[0].keys).to match_array(["type_label", "type_name", "text"])
+      expect(subject[0].keys).to match_array(["type_label", "type_name", "text", "images"])
 
       # The second element is a non-scenario Question, and thus has data.
-      expect(subject[1].keys).to match_array(["type_label", "type_name", "text", "data"])
+      expect(subject[1].keys).to match_array(["type_label", "type_name", "text", "data", "images"])
     end
   end
 end


### PR DESCRIPTION
This comit will fix the issue with stimulus case study sub-questions not being able to display their images.

Ref
- https://github.com/notch8/viva/issues/376

## Before:
![image](https://github.com/user-attachments/assets/1e46e975-e154-432e-a78d-61cffe6eda00)

## After:
![image](https://github.com/user-attachments/assets/68e8d7c9-acb7-45b9-8bfc-2ba550717fe3)
