### PR TITLE
🧹 fixes dependency issue

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,7 @@
+supportedArchitectures:
+  os:
+    - darwin
+    - linux
+  cpu:
+    - x64
+    - arm64 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,19 @@ RUN apt-get update -qq && \
     apt-get install -y \
     nodejs \
     postgresql-client \
-    vim-tiny && \
+    vim-tiny \
+    # Cypress dependencies
+    xvfb \
+    libgtk2.0-0 \
+    libgtk-3-0 \
+    libgbm-dev \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libxtst6 \
+    xauth && \
     npm install -g yarn
 
 ENV APP_HOME /app
@@ -30,7 +42,8 @@ RUN (bundle check || bundle install)
 
 ADD package.json ./package.json
 ADD yarn.lock ./yarn.lock
-RUN yarn install
+ADD .yarnrc.yml ./.yarnrc.yml
+RUN yarn install --network-timeout 100000
 
 COPY . $APP_HOME
 RUN bash -l -c " \

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -17,6 +17,7 @@ module.exports = defineConfig({
   },
   e2e: {
     baseUrl: 'http://web:3000',
+    // baseUrl: 'http://viva.test', // uncomment to run Cypress against the local Rails app (outside of Docker)
     chromeWebSecurity: false,
     setupNodeEvents(on, config) { // eslint-disable-line no-unused-vars
       // implement node event listeners here

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "cypress": "13.2.0",
     "eslint": "^8.49.0",
     "eslint-plugin-react": "^7.33.2"
+  },
+  "optionalDependencies": {
+    "@esbuild/darwin-arm64": "^0.18.0",
+    "@esbuild/linux-x64": "^0.18.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,7 +277,7 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
   integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
 
-"@esbuild/darwin-arm64@0.18.20":
+"@esbuild/darwin-arm64@0.18.20", "@esbuild/darwin-arm64@^0.18.0":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
   integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
@@ -342,7 +342,7 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
   integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
 
-"@esbuild/linux-x64@0.18.20":
+"@esbuild/linux-x64@0.18.20", "@esbuild/linux-x64@^0.18.0":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
   integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==


### PR DESCRIPTION
This should fix the reason we couldn't run `yarn cypress:run --component`