### PR TITLE
🐛 Fixes Canvas integration bug in Select All

### DIFF
--- a/app/views/question/select_all_that_applies/_select_all_that_apply.xml.erb
+++ b/app/views/question/select_all_that_applies/_select_all_that_apply.xml.erb
@@ -40,9 +40,9 @@
       <conditionvar>
         <and>
 	  <% select_all_that_apply.with_each_choice_index_label_and_correctness do |index, _label, correctness| %>
-	    <% if correctness %><not><% end %>
+	    <% if !correctness %><not><% end %>
 	      <varequal respident="response_<%= select_all_that_apply.item_ident %>"><%= select_all_that_apply.item_ident %>-<%= index %></varequal>
-	      <% if correctness %></not><% end %>
+	      <% if !correctness %></not><% end %>
 	  <% end %>
         </and>
       </conditionvar>


### PR DESCRIPTION
author @sjproctor 

This commit fixes a bug in the Select All That Apply question type that was causing the answer correctness to be inverted. The `<not>` XML tag which indicates incorrect answers was being applied to correct answers.

Ref:
- https://github.com/notch8/viva/issues/339

## BEFORE

![FireShot Capture 046 - Viva Questions for March 3, 2025 904046500_ DEMO -  canvas instructure com](https://github.com/user-attachments/assets/13f05ea9-d717-4a2c-8769-d2aacf62afc6)


## AFTER
![FireShot Capture 045 - Viva Questions for March 3, 2025 038277959_ DEMO -  canvas instructure com](https://github.com/user-attachments/assets/df732291-430b-4040-96bc-856943736bbe)


## CORRECT ANSWERS SHOULD MATCH WHAT WAS EXPORTED FROM VIVA: 
![image](https://github.com/user-attachments/assets/28273c19-9b95-4a91-bf9c-41dd45060e09)
