### PR TITLE
Fix Bookmark downloads

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -26,7 +26,8 @@ class BookmarksController < ApplicationController
   end
 
   def export
-    @questions = Question.where(id: current_user.bookmarks.select(:question_id))
+    @questions = current_user.bookmarked_questions
+
     case params[:format]
     when 'md'
       service = QuestionFormatter::MarkdownService


### PR DESCRIPTION
Fixes the ability to download a user's bookmarks.
Adds a bit more to the specs verifying only the given user's bookmarks, and nothing that is not bookmarked.

The apparent cause of the bug was that the @questions loading was returning ids rather than full questions. 

Refs prior work: 
- https://github.com/notch8/viva/pull/389
- https://github.com/notch8/viva/pull/385
