### PR TITLE
🐛 Remove trucation in the searchable attribute

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -578,7 +578,6 @@ class Question < ApplicationRecord
         .gsub(/\s+/, ' ')
         .strip
         .downcase
-        .truncate(1000)
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
This commit will remove the truncation from the final scrub of the text that goes into the searchable attribute.  We might want to see how this goes in production without a trucation and maybe put one in place if it affects performance.

Ref:
- https://github.com/notch8/viva/issues/394
