### PR TITLE
🧹 Sort types

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -133,7 +133,7 @@ class Question < ApplicationRecord
   def self.type_names
     Question.descendants.each_with_object([]) do |descendant, array|
       array << descendant.type_name if descendant.included_in_filterable_type
-    end
+    end.sort
   end
 
   ##


### PR DESCRIPTION
This commit will make it so that the .type_names method returns the types sorted alphabetically.

Ref:
- https://github.com/notch8/viva/issues/396

<img width="399" alt="image" src="https://github.com/user-attachments/assets/25394e64-403f-42a9-93f0-835accf2bc8d" />
