### PR TITLE
🐛 Fix Upload Question type for Canvas

### DIFF
--- a/app/views/question/uploads/_upload.xml.erb
+++ b/app/views/question/uploads/_upload.xml.erb
@@ -2,7 +2,7 @@
   <itemmetadata>
     <qtimetadatafield>
       <fieldlabel>question_type</fieldlabel>
-      <fieldentry>essay_question</fieldentry>
+      <fieldentry>file_upload_question</fieldentry>
     </qtimetadatafield>
     <qtimetadatafield>
       <fieldlabel>points_possible</fieldlabel>

--- a/spec/views/question/uploads/_upload.xml.erb_spec.rb
+++ b/spec/views/question/uploads/_upload.xml.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'question/uploads/_upload' do
     # Yes the format type is essay question; perhaps there's a nuance that means Upload and Essay
     # are not identical; but this is what was requested so I'm assuming there's differences
     # somewhere.
-    expect(rendered).to include(%(<fieldentry>essay_question</fieldentry>))
+    expect(rendered).to include(%(<fieldentry>file_upload_question</fieldentry>))
 
     # We are providing HTML and want to ensure it is escaped
     expect(rendered).to include(%(<mattext texttype="text/html">&lt;))


### PR DESCRIPTION
Prior to this commit, Upload question types were being imported into canvas incorrectly, they were imported as essay questions.  This commit will change correct that.

Ref:
- https://github.com/notch8/viva/issues/401

![image](https://github.com/user-attachments/assets/5ecbedea-9d6f-4cc2-b796-c416bf9ae9eb)

![image](https://github.com/user-attachments/assets/45f7bdfb-6e42-4447-aed8-8ee27352259d)
