### PR TITLE
♻️ Refactor base64 encode method

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -14,7 +14,7 @@ class Image < ApplicationRecord
     file.blob.filename.to_s
   end
 
-  def binary_data
-    file.download
+  def base64_encoded_data
+    Base64.strict_encode64(file.download)
   end
 end

--- a/app/services/question_formatter/moodle_service.rb
+++ b/app/services/question_formatter/moodle_service.rb
@@ -96,7 +96,7 @@ module QuestionFormatter
     def add_image_files
       question.images.each do |image|
         xml.file(name: image.original_filename, path: '/', encoding: 'base64') do
-          xml << binary_base_64(image)
+          xml << image.base64_encoded_data
         end
       end
     end
@@ -105,10 +105,6 @@ module QuestionFormatter
       question.images.map do |image|
         "<p><img src=\"@@PLUGINFILE@@/#{image.original_filename}\" alt=\"#{image.alt_text}\"></p>"
       end
-    end
-
-    def binary_base_64(image)
-      Base64.strict_encode64(image.binary_data)
     end
 
     def text_cdata_wrapper(text)


### PR DESCRIPTION
This commit will refactor the base64 encode method to be on the Image model so other services can use it becuase we don't ever use the raw binary.