### PR TITLE
💄 Using pluck instead of select for bookmarks

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -26,7 +26,7 @@ class BookmarksController < ApplicationController
   end
 
   def export
-    @questions = Question.where(id: current_user.bookmarks.select(:question_id))
+    @questions = Question.where(id: current_user.bookmarks.pluck(:question_id))
     case params[:format]
     when 'md'
       service = QuestionFormatter::MarkdownService


### PR DESCRIPTION
# Story: [i349] Bookmark bug fix

Ref:
- https://github.com/notch8/viva/issues/349

## Notes

This commit updates the export method in the bookmarks controller to use pluck instead of select when getting all the current user's bookmarks. Pluck returns only the ID rather than returning the entire record.

No changes to the user experience.