### PR TITLE
🎁 Adds Upload form and subquestion options

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -86,7 +86,7 @@ class Api::QuestionsController < ApplicationController
       processed[:data] = process_categorization_data(processed[:data])
     when 'Question::DragAndDrop'
       processed[:data] = process_drag_and_drop_data(processed[:data])
-    when 'Question::Essay'
+    when 'Question::Essay', 'Question::Upload'
       processed[:data] = process_essay_data(processed[:data])
     when 'Question::BowTie'
       processed[:data] = process_bow_tie_data(processed[:data])
@@ -209,12 +209,13 @@ class Api::QuestionsController < ApplicationController
     when 'Question::Matching'
       process_matching_data(data)
     when 'Question::BowTie'
-      default_bow_tie_data = {
+      process_bow_tie_data(data) || {
         'left' => { 'answers' => [] },
         'right' => { 'answers' => [] },
         'center' => { 'answers' => [] }
       }
-      process_bow_tie_data(data) || default_bow_tie_data
+    when 'Question::Essay', 'Question::Upload'
+      process_essay_data(data)
     else
       data
     end
@@ -259,7 +260,8 @@ class Api::QuestionsController < ApplicationController
       'Multiple Choice' => 'Question::Traditional',
       'Select All That Apply' => 'Question::SelectAllThatApply',
       'Scenario' => 'Question::Scenario',
-      'Stimulus Case Study' => 'Question::StimulusCaseStudy'
+      'Stimulus Case Study' => 'Question::StimulusCaseStudy',
+      'Upload' => 'Question::Upload'
     }
 
     type_mapping[type] || type

--- a/app/javascript/components/ui/CreateQuestionForm/StimulusCaseStudy.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/StimulusCaseStudy.jsx
@@ -11,6 +11,7 @@ import Essay from './Essay'
 import Matching from './Matching'
 import MultipleChoice from './MultipleChoice'
 import SelectAllThatApply from './SelectAllThatApply'
+import Upload from './Upload'
 import QuestionTypeDropdown from './QuestionTypeDropdown'
 import QuestionText from './QuestionText'
 
@@ -28,6 +29,7 @@ const StimulusCaseStudy = ({ questionText, handleTextChange, onDataChange, reset
       'Matching': Matching,
       'Multiple Choice': MultipleChoice,
       'Select All That Apply': SelectAllThatApply,
+      'Upload': Upload
     }),
     []
   )
@@ -51,6 +53,7 @@ const StimulusCaseStudy = ({ questionText, handleTextChange, onDataChange, reset
     case 'Categorization':
       return [{ answer: '', correct: [] }]
     case 'Essay':
+    case 'Upload':
       return { html: '<p></p>' }
     default:
       return null
@@ -95,7 +98,7 @@ const StimulusCaseStudy = ({ questionText, handleTextChange, onDataChange, reset
         const updated = prev.map((sq) => {
           if (sq.id === id) {
             const updatedSq = { ...sq, [key]: value }
-            if (sq.type === 'Essay' && key === 'text') {
+            if ((sq.type === 'Essay' || sq.type === 'Upload') && key === 'text') {
               updatedSq.data = {
                 html: value
                   .split('\n')

--- a/app/javascript/components/ui/CreateQuestionForm/Upload.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Upload.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Form } from 'react-bootstrap'
+
+const Upload = ({ questionText, handleTextChange }) => {
+  return (
+    <Form.Group className='mb-3'>
+      <Form.Label>Question Text</Form.Label>
+      <Form.Control
+        as='textarea'
+        rows={3}
+        value={questionText}
+        onChange={handleTextChange}
+        placeholder='Enter your question text here...'
+      />
+    </Form.Group>
+  )
+}
+
+export default Upload

--- a/app/javascript/components/ui/CreateQuestionForm/index.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/index.jsx
@@ -8,6 +8,7 @@ import Matching from './Matching'
 import MultipleChoice from './MultipleChoice'
 import SelectAllThatApply from './SelectAllThatApply'
 import StimulusCaseStudy from './StimulusCaseStudy'
+import Upload from './Upload'
 import QuestionTypeDropdown from './QuestionTypeDropdown'
 import LevelDropdown from './LevelDropdown'
 // import Keyword from './Keyword'
@@ -35,6 +36,7 @@ const CreateQuestionForm = ({ subjectOptions }) => {
     'Multiple Choice': MultipleChoice,
     'Select All That Apply': SelectAllThatApply,
     'Stimulus Case Study': StimulusCaseStudy,
+    'Upload': Upload
   }
 
   const QuestionComponent = COMPONENT_MAP[questionType] || null
@@ -91,7 +93,14 @@ const CreateQuestionForm = ({ subjectOptions }) => {
       'Bow Tie': () => data && appendData(data),
       'Multiple Choice': () => appendData(filterValidData(data)),
       'Select All That Apply': () => appendData(filterValidData(data)),
-      'Stimulus Case Study': () => appendData(data)
+      'Stimulus Case Study': () => appendData(data),
+      Upload: () =>
+        appendData({
+          html: questionText
+            .split('\n')
+            .map((line, index) => `<p key=${index}>${line}</p>`)
+            .join('')
+        })
     }
 
     if (handlers[questionType]) {

--- a/app/javascript/constants/questionTypes.js
+++ b/app/javascript/constants/questionTypes.js
@@ -7,7 +7,7 @@ export const QUESTION_TYPE_NAMES = [
   { key: 'Traditional', value: 'Multiple Choice' },
   { key: 'Select All That Apply', value: 'Select All That Apply' },
   { key: 'Case Study', value: 'Stimulus Case Study' },
-  // { key: 'Upload', value: 'Upload' },
+  { key: 'Upload', value: 'Upload' },
 ]
 
 export const SUBQUESTION_TYPE_NAMES = [
@@ -18,5 +18,6 @@ export const SUBQUESTION_TYPE_NAMES = [
   { key: 'Essay', value: 'Essay' },
   { key: 'Matching', value: 'Matching' },
   { key: 'Traditional', value: 'Multiple Choice' },
-  { key: 'Select All That Apply', value: 'Select All That Apply' }
+  { key: 'Select All That Apply', value: 'Select All That Apply' },
+  { key: 'Upload', value: 'Upload' }
 ]

--- a/spec/models/question/upload_spec.rb
+++ b/spec/models/question/upload_spec.rb
@@ -2,9 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe Question::Upload do
-  it_behaves_like "a Question", export_as_xml: true
+RSpec.describe Question::Upload, type: :model do
+  it_behaves_like "a Question", valid: true, export_as_xml: true
   it_behaves_like "a Markdown Question"
+
   its(:type_label) { is_expected.to eq("Question") }
   its(:type_name) { is_expected.to eq("Upload") }
+  its(:model_exporter) { is_expected.to eq('essay_type') }
+  its(:export_as_xml) { is_expected.to eq(true) }
+  its(:d2l_export_type) { is_expected.to eq('WR') }
 end


### PR DESCRIPTION
# Story: Adds Upload Type to Form and Stimulus Subquestion

## Expected Behavior Before Changes

Upload was not an option on the form or stimulus case study subquestion

## Expected Behavior After Changes

- User can select Upload from the upload a question form
- User can select Upload as a subquestion when creating a Stimulus Case Study

## Screenshots / Video

<details>
<summary>Photo: Upload on the list of questions</summary>

<img width="1044" alt="Screenshot 2025-03-10 at 8 06 10 PM" src="https://github.com/user-attachments/assets/928a7c44-85e5-4b3a-93b1-5530d1382dcf" />

</details>

<details>
<summary>Photo: Upload on the list of subquestions for Stimulus Case Study</summary>

<img width="1424" alt="Screenshot 2025-03-10 at 8 07 04 PM" src="https://github.com/user-attachments/assets/34236a1f-5e29-4704-a30f-cff9b4d667be" />

</details>

<details>
<summary>Photo: Created Upload question and subquestion</summary>
<img width="1183" alt="Screenshot 2025-03-10 at 8 11 05 PM" src="https://github.com/user-attachments/assets/45536baa-7b8a-4b48-8906-689f49de39f9" />

</details>