### PR TITLE
🧹[i428] - export buttons design follow up

### DIFF
--- a/app/javascript/components/ui/Export/Export.css
+++ b/app/javascript/components/ui/Export/Export.css
@@ -1,26 +1,56 @@
-.export-button {
-  width: 330px;
-  height: 150px;
-  border-radius: 8px;
+.export-button-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   margin: 10px;
+  flex: 1;
+}
+
+.export-button {
+  width: 100%;
+  height: 120px;
+  border: 1px solid #0d6efd;
+  border-radius: 4px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  padding: 20px;
+  background-color: white;
 }
 
 .export-button i {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
+  font-size: 2rem;
+  color: #0d6efd;
+  margin-bottom: 0.5rem;
 }
 
 .export-button span {
+  color: #0d6efd;
   text-transform: uppercase;
+  font-size: 1rem;
+  font-weight: 500;
 }
 
-/* Tooltip styling */
-.tooltip .tooltip-inner {
-  max-width: 300px;
-  padding: 8px 12px;
-  font-size: 0.9rem;
-} 
+.supported-types {
+  text-align: center;
+  color: #666;
+  font-size: 0.8rem;
+  margin-top: 0.5rem;
+}
+
+.supported-types div {
+  margin: 2px 0;
+}
+
+/* Add hover state */
+.export-button:hover:not(:disabled) {
+  background-color: #f8f9fa;
+  text-decoration: none;
+}
+
+.export-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+

--- a/app/javascript/components/ui/Export/ExportButton.jsx
+++ b/app/javascript/components/ui/Export/ExportButton.jsx
@@ -1,19 +1,8 @@
 import React from 'react'
-import {Button, OverlayTrigger, Tooltip} from 'react-bootstrap'
+import {Button} from 'react-bootstrap'
 import './Export.css'
 
 const ExportButton = ({ format, label, questionTypes, hasBookmarks }) => {
-  const getTooltipText = (format, questionTypes) => {
-    if (questionTypes.length === 0) {
-      if (format === 'md') {
-        return 'Supports all question types in markdown format'
-      }
-      return 'Supports all question types in plain text format'
-    }
-
-    return `Supports: ${questionTypes.join(', ')}`
-  }
-
   const getIconClass = (format) => {
     switch (format) {
     case 'blackboard':
@@ -33,24 +22,30 @@ const ExportButton = ({ format, label, questionTypes, hasBookmarks }) => {
     }
   }
 
+  const isTextFormat = format === 'md' || format === 'txt'
+
   return (
-    <div className='col-md-6 d-flex justify-content-center'>
-      <OverlayTrigger
-        placement='top'
-        overlay={<Tooltip>{getTooltipText(format, questionTypes)}</Tooltip>}
+    <div className='export-button-container'>
+      <Button
+        variant='outline-primary'
+        className='export-button'
+        href={`/bookmarks/export?format=${format}`}
+        disabled={!hasBookmarks}
+        data-cy={`export-button-${format}`}
+        data-format={format}
       >
-        <Button
-          variant='outline-primary'
-          className='export-button'
-          href={`/bookmarks/export?format=${format}`}
-          disabled={!hasBookmarks}
-          data-cy={`export-button-${format}`}
-          data-format={format}
-        >
-          <i className={`bi ${getIconClass(format)} fs-1 mb-3`}></i>
-          <span className='text-uppercase'>{label}</span>
-        </Button>
-      </OverlayTrigger>
+        <i className={`bi ${getIconClass(format)}`}></i>
+        <span>{label}</span>
+      </Button>
+      <div className='supported-types'>
+        {isTextFormat ? (
+          <div>All Question Types Supported</div>
+        ) : (
+          questionTypes.map((type, index) => (
+            <div key={index}>{type}</div>
+          ))
+        )}
+      </div>
     </div>
   )
 }

--- a/app/javascript/components/ui/Export/ExportModal.jsx
+++ b/app/javascript/components/ui/Export/ExportModal.jsx
@@ -17,30 +17,23 @@ const ExportModal = ({ show, onHide, hasBookmarks }) => {
       <Modal.Body>
         <Tabs defaultActiveKey='lms' className='mb-3'>
           <Tab eventKey='lms' title='Learning Management Systems'>
-            <div className='d-flex flex-wrap justify-content-center'>
-              <div className='row w-100'>
-                <ExportButton format='blackboard' label='Blackboard' questionTypes={lms.blackboard} hasBookmarks={hasBookmarks} />
-                <ExportButton format='d2l' label='Brightspace' questionTypes={lms.d2l} hasBookmarks={hasBookmarks} />
-              </div>
-              <div className='row w-100'>
-                <ExportButton format='canvas' label='Canvas' questionTypes={lms.canvas} hasBookmarks={hasBookmarks} />
-                <ExportButton format='moodle' label='Moodle' questionTypes={lms.moodle} hasBookmarks={hasBookmarks} />
-              </div>
+            <div className='d-flex justify-content-between'>
+              <ExportButton format='canvas' label='Canvas' questionTypes={lms.canvas} hasBookmarks={hasBookmarks} />
+              <ExportButton format='blackboard' label='Blackboard' questionTypes={lms.blackboard} hasBookmarks={hasBookmarks} />
+              <ExportButton format='d2l' label='Brightspace (D2L)' questionTypes={lms.d2l} hasBookmarks={hasBookmarks} />
+              <ExportButton format='moodle' label='Moodle' questionTypes={lms.moodle} hasBookmarks={hasBookmarks} />
             </div>
           </Tab>
-
           <Tab eventKey='text' title='Text Formats'>
             <div className='d-flex justify-content-center'>
-              <div className='row w-100'>
-                <ExportButton format='md' label='Markdown' questionTypes={[]} hasBookmarks={hasBookmarks} />
-                <ExportButton format='txt' label='Plain Text' questionTypes={[]} hasBookmarks={hasBookmarks} />
-              </div>
+              <ExportButton format='md' label='Markdown' questionTypes={[]} hasBookmarks={hasBookmarks} />
+              <ExportButton format='txt' label='Plain Text' questionTypes={[]} hasBookmarks={hasBookmarks} />
             </div>
           </Tab>
         </Tabs>
       </Modal.Body>
       <Modal.Footer>
-        <Button variant='secondary' onClick={onHide} className='px-4'>
+        <Button variant='secondary' onClick={onHide}>
           Close
         </Button>
       </Modal.Footer>

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -183,7 +183,7 @@ class Question < ApplicationRecord
   # @return [Array<String>] Sorted array of question type names that support the given LMS
   # @api private
   def self.lms_finder(lms)
-    Question.descendants.select(&lms).map(&:type_name).sort
+    Question.descendants.select(&lms).map { |q| q.respond_to?(:display_name) ? q.display_name : q.type_name }.sort
   end
   private_class_method :lms_finder
 

--- a/app/models/question/upload.rb
+++ b/app/models/question/upload.rb
@@ -14,6 +14,10 @@ class Question::Upload < Question
   self.canvas_export_type = true
   self.d2l_export_type = 'WR'
 
+  def self.display_name
+    "File Upload"
+  end
+
   class ImportCsvRow < MarkdownQuestionBehavior::ImportCsvRow
   end
 end


### PR DESCRIPTION
This design removes the hovering tool tip. Now users can immediately see what export types are available with each export button.

Issue
- https://github.com/notch8/viva/issues/428

## before

![Image](https://github.com/user-attachments/assets/beb8ca77-0d99-411b-993b-ad38ca5953d6)


## after

<img width="580" alt="image" src="https://github.com/user-attachments/assets/a4e814b3-0b2a-4768-a8f0-340aef412a63" />


![Zight Recording 2025-03-12 at 10 29 16 AM](https://github.com/user-attachments/assets/f9e33ee3-675a-4c20-9b97-0c35abdc6d95)

## MOCK

![image](https://github.com/user-attachments/assets/ef66c5a7-2901-4b84-a691-0a49f3e0d3da)
