### PR TITLE
🎁 Make D2L export a zip with images (if any)

### DIFF
--- a/app/services/bookmark_export_service.rb
+++ b/app/services/bookmark_export_service.rb
@@ -106,7 +106,7 @@ class BookmarkExportService
   #
   # @return [Hash] A hash containing the export data, filename, and content type
   def d2l_export(data)
-    export_result(data:)
+    export_result(data:, is_file: true)
   end
 
   # Export bookmarks in Moodle XML format

--- a/app/services/bookmark_export_service.rb
+++ b/app/services/bookmark_export_service.rb
@@ -29,18 +29,12 @@ class BookmarkExportService
     @requested_format = requested_format
     @formatter_service = formatter_service_for(requested_format).new(questions)
 
-    export_content = formatter_service.format_content
-    export_method = "#{requested_format}_export"
-
-    if respond_to?(export_method, true)
-      send(export_method, export_content)
-    else
-      "Format #{requested_format} is not yet supported for export"
-    end
+    export_result(data: formatter_service.format_content)
   end
 
   private
 
+  # rubocop:disable Metrics/MethodLength
   def formatter_service_for(requested_format)
     case requested_format
     when 'txt'
@@ -55,8 +49,11 @@ class BookmarkExportService
       QuestionFormatter::D2lService
     when 'moodle'
       QuestionFormatter::MoodleService
+    else
+      raise "Format #{requested_format} is not yet supported for export"
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def file_name(suffix: formatter_service.output_format)
     "questions-#{requested_format}-#{Time.current.strftime('%Y-%m-%d_%H:%M:%S:%L')}.#{suffix}"
@@ -65,68 +62,7 @@ class BookmarkExportService
   def export_result(data:,
                     filename: file_name,
                     type: formatter_service.file_type,
-                    is_file: false)
+                    is_file: formatter_service.is_file)
     { data:, filename:, type:, is_file: }
-  end
-
-  # Export bookmarks in Canvas QTI format
-  #
-  # @return [Hash] A hash containing the export data, filename, content type, and file flag
-  def canvas_export(data)
-    data.is_a?(Tempfile) ? canvas_zip_export(data) : canvas_xml_export(data)
-  end
-
-  # Create export hash for Canvas zip file
-  #
-  # @param temp_file [Tempfile] The zip file containing Canvas export
-  # @return [Hash] A hash containing the export data, filename, content type, and file flag
-  def canvas_zip_export(data)
-    export_result(data:,
-                  filename: file_name(suffix: 'zip'),
-                  type: 'application/zip',
-                  is_file: true)
-  end
-
-  # Create export hash for Canvas XML content
-  #
-  # @param xml_content [String] The XML content for Canvas export
-  # @return [Hash] A hash containing the export data, filename, content type, and file flag
-  def canvas_xml_export(data)
-    export_result(data:)
-  end
-
-  # Export bookmarks in Blackboard format
-  #
-  # @return [Hash] A hash containing the export data, filename, and content type
-  def blackboard_export(data)
-    export_result(data:)
-  end
-
-  # Export bookmarks in Brightspace/D2L format
-  #
-  # @return [Hash] A hash containing the export data, filename, and content type
-  def d2l_export(data)
-    export_result(data:, is_file: true)
-  end
-
-  # Export bookmarks in Moodle XML format
-  #
-  # @return [Hash] A hash containing the export data, filename, and content type
-  def moodle_export(data)
-    export_result(data:)
-  end
-
-  # Export bookmarks as plain text
-  #
-  # @return [Hash] A hash containing the export data, filename, content type, and file flag
-  def txt_export(data)
-    export_result(data:)
-  end
-
-  # Export bookmarks as markdown
-  #
-  # @return [Hash] A hash containing the export data, filename, content type, and file flag
-  def md_export(data)
-    export_result(data:)
   end
 end

--- a/app/services/question_formatter/base_service.rb
+++ b/app/services/question_formatter/base_service.rb
@@ -9,6 +9,7 @@ module QuestionFormatter
     class_attribute :output_format, default: nil
     class_attribute :format, default: nil
     class_attribute :file_type, default: nil
+    class_attribute :is_file, default: false
 
     attr_reader :questions, :subq, :question
 

--- a/app/services/question_formatter/canvas_service.rb
+++ b/app/services/question_formatter/canvas_service.rb
@@ -4,9 +4,10 @@
 # Service to handle formatting questions into Canvas's dti format
 module QuestionFormatter
   class CanvasService < BaseService
-    self.output_format = 'xml' # used as file suffix
+    self.output_format = 'zip' # used as file suffix
     self.format = 'canvas' # used as format parameter
-    self.file_type = 'application/xml'
+    self.file_type = 'application/zip'
+    self.is_file = true
 
     def format_content
       # Canvas uses the QTI XML format

--- a/app/services/question_formatter/canvas_service.rb
+++ b/app/services/question_formatter/canvas_service.rb
@@ -21,7 +21,7 @@ module QuestionFormatter
       images = questions.flat_map(&:images)
 
       # Use ZipFileService to create the zip file
-      zip_file_service = ZipFileService.new(images, xml_content, xml_filename)
+      zip_file_service = ZipFileService.new(images, xml_content, xml_filename, 'questions')
       temp_file = zip_file_service.generate_zip
       add_manifest!(temp_file)
       # Return the temp file object (not just the data)

--- a/app/services/question_formatter/d2l_service.rb
+++ b/app/services/question_formatter/d2l_service.rb
@@ -6,9 +6,9 @@ require 'csv'
 # Service to handle formatting questions into D2L's CSV format
 module QuestionFormatter
   class D2lService < BaseService
-    self.output_format = 'csv' # used as file suffix
+    self.output_format = 'zip' # used as file suffix
     self.format = 'd2l' # used as format parameter
-    self.file_type = 'text/csv'
+    self.file_type = 'application/zip'
 
     attr_reader :questions, :question
 
@@ -19,7 +19,7 @@ module QuestionFormatter
     end
 
     def format_content
-      csv_string = CSV.generate do |csv|
+      csv_content = CSV.generate do |csv|
         @questions.each do |question|
           next if question.d2l_export_type.nil?
           @question = question
@@ -29,8 +29,13 @@ module QuestionFormatter
             csv << row
           end
         end
-      end
-      csv_string.encode('UTF-8')
+      end.encode('UTF-8')
+
+      csv_filename = 'questions.csv'
+      images = questions.flat_map(&:images)
+
+      zip_file_service = ZipFileService.new(images, csv_content, csv_filename)
+      zip_file_service.generate_zip
     end
 
     private
@@ -46,29 +51,11 @@ module QuestionFormatter
       csv_rows
     end
 
-    def image_url
-      image_url = question.images&.first&.url
-      return nil if image_url.blank?
-      return image_url if base_url.blank?
-      base_url + image_url
-    end
-
-    def base_url
-      default_url_options = Rails.application.config.action_mailer.default_url_options
-      return nil if default_url_options.blank?
-      host = default_url_options[:host]
-      port = default_url_options[:port]
-      return nil if host.blank? || port.blank?
-      "http://#{host}:#{port}"
-    end
-
-    ## called by format type
-
     def traditional_type
       csv_rows = []
       csv_rows += shared_opening_rows
       csv_rows << ['QuestionText', question.text]
-      csv_rows << ['Image', image_url] if image_url
+      csv_rows << ['Image', image_paths].flatten if question.images.present?
       csv_rows += format_traditional_options(@question.data)
       csv_rows
     end
@@ -77,7 +64,7 @@ module QuestionFormatter
       csv_rows = []
       csv_rows += shared_opening_rows
       csv_rows << ['QuestionText', question.text]
-      csv_rows << ['Image', image_url] if image_url
+      csv_rows << ['Image', image_paths].flatten if question.images.present?
       csv_rows += format_matching_options(@question.data)
       csv_rows
     end
@@ -87,7 +74,7 @@ module QuestionFormatter
       csv_rows += shared_opening_rows
       csv_rows << ['Title', question.text]
       csv_rows << ['QuestionText', question.data['html'], 'HTML']
-      csv_rows << ['Image', image_url] if image_url
+      csv_rows << ['Image', image_paths].flatten if question.images.present?
       csv_rows
     end
 
@@ -117,6 +104,12 @@ module QuestionFormatter
       end
 
       choice_rows + match_rows
+    end
+
+    def image_paths
+      question.images.map do |image|
+        "images/#{image.original_filename}"
+      end
     end
   end
 end

--- a/app/services/question_formatter/d2l_service.rb
+++ b/app/services/question_formatter/d2l_service.rb
@@ -9,6 +9,7 @@ module QuestionFormatter
     self.output_format = 'zip' # used as file suffix
     self.format = 'd2l' # used as format parameter
     self.file_type = 'application/zip'
+    self.is_file = true
 
     attr_reader :questions, :question
 

--- a/app/services/question_formatter/moodle_service.rb
+++ b/app/services/question_formatter/moodle_service.rb
@@ -5,7 +5,7 @@ module QuestionFormatter
   class MoodleService < BaseService
     self.output_format = 'xml'
     self.format = 'moodle' # used as format parameter
-    self.file_type = 'application/xml'
+    self.file_type = 'text/xml'
 
     attr_accessor :xml
 

--- a/spec/services/bookmark_export_service_spec.rb
+++ b/spec/services/bookmark_export_service_spec.rb
@@ -20,157 +20,145 @@ RSpec.describe BookmarkExportService do
   end
 
   describe '#export' do
-    it 'calls the appropriate export method dynamically based on format' do
-      expect(service).to receive(:send).with('txt_export', anything)
-      service.export('txt')
-
-      expect(service).to receive(:send).with('md_export', anything)
-      service.export('md')
-
-      expect(service).to receive(:send).with('canvas_export', anything)
-      service.export('canvas')
-
-      expect(service).to receive(:send).with('blackboard_export', anything)
-      service.export('blackboard')
-
-      expect(service).to receive(:send).with('d2l_export', anything)
-      service.export('d2l')
-
-      expect(service).to receive(:send).with('moodle_export', anything)
-      service.export('moodle')
-    end
-  end
-
-  describe 'export formats' do
-    describe '#txt_export' do
-      let(:formatter_klass) { QuestionFormatter::PlainTextService }
-
-      before do
-        allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('text content')
-      end
-
-      it 'returns a hash with text data' do
-        result = service.export('txt')
-
-        expect(result[:data]).to eq('text content')
-        expect(result[:filename]).to match(/questions-txt.*\.txt/)
-        expect(result[:type]).to eq('text/plain')
-        expect(result[:is_file]).to be false
-      end
-    end
-
-    describe '#md_export' do
-      let(:formatter_klass) { QuestionFormatter::MarkdownService }
-
-      before do
-        allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('markdown content')
-      end
-
-      it 'returns a hash with markdown data' do
-        result = service.export('md')
-
-        expect(result[:data]).to eq('markdown content')
-        expect(result[:filename]).to match(/questions-md.*\.md/)
-        expect(result[:type]).to eq('text/plain')
-        expect(result[:is_file]).to be false
-      end
-    end
-
-    describe '#canvas_export' do
-      let(:formatter_klass) { QuestionFormatter::CanvasService }
-      let(:xml_content) { '<xml>content</xml>' }
-
-      before do
-        allow(ApplicationController).to receive(:render).and_return(xml_content)
-      end
-
-      context 'when questions have no images' do
-        before do
-          allow(question1).to receive(:images).and_return([])
-          allow(question2).to receive(:images).and_return([])
-        end
-
-        it 'returns a hash with XML data' do
-          result = service.export('canvas')
-
-          expect(result[:filename]).to match(/questions-canvas.*\.zip/)
-          expect(result[:type]).to eq('application/zip')
-          expect(result[:is_file]).to be true
-        end
-      end
-
-      context 'when questions have images' do
-        let(:image) { double('Image') }
-        let(:images) { double('ActiveRecord::Associations::CollectionProxy', any?: true) }
-        let(:question_with_images) { build_stubbed(:question_traditional) }
-        let(:bookmark_with_images) { build_stubbed(:bookmark, user:, question: question_with_images) }
-        let(:service_with_images) { described_class.new([bookmark_with_images]) }
-        let(:temp_file) { Tempfile.new(['test', '.zip']) }
-        let(:zip_service) { instance_double(ZipFileService) }
+    context 'when it is a text export' do
+      context 'plain text' do
+        let(:formatter_klass) { QuestionFormatter::PlainTextService }
 
         before do
-          allow(question_with_images).to receive(:images).and_return(images)
-          # allow(images).to receive(:any?).and_return(true)
-          allow(ZipFileService).to receive(:new).and_return(zip_service)
-          allow(zip_service).to receive(:generate_zip).and_return(temp_file)
+          allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('text content')
         end
 
-        it 'returns a hash with a zip file' do
-          result = service_with_images.export('canvas')
+        it 'returns a hash with text data' do
+          result = service.export('txt')
 
-          expect(result[:data]).to eq(temp_file)
-          expect(result[:filename]).to match(/questions-canvas.*\.zip/)
+          expect(result[:data]).to eq('text content')
+          expect(result[:filename]).to match(/questions-txt.*\.txt/)
+          expect(result[:type]).to eq('text/plain')
+          expect(result[:is_file]).to be false
+        end
+      end
+
+      context 'markdown' do
+        let(:formatter_klass) { QuestionFormatter::MarkdownService }
+
+        before do
+          allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('markdown content')
+        end
+
+        it 'returns a hash with markdown data' do
+          result = service.export('md')
+
+          expect(result[:data]).to eq('markdown content')
+          expect(result[:filename]).to match(/questions-md.*\.md/)
+          expect(result[:type]).to eq('text/plain')
+          expect(result[:is_file]).to be false
+        end
+      end
+    end
+
+    context 'when it is an LMS export' do
+      context 'canvas' do
+        let(:formatter_klass) { QuestionFormatter::CanvasService }
+        let(:xml_content) { '<xml>content</xml>' }
+
+        before do
+          allow(ApplicationController).to receive(:render).and_return(xml_content)
+        end
+
+        context 'when questions have no images' do
+          before do
+            allow(question1).to receive(:images).and_return([])
+            allow(question2).to receive(:images).and_return([])
+          end
+
+          it 'returns a hash with XML data' do
+            result = service.export('canvas')
+
+            expect(result[:filename]).to match(/questions-canvas.*\.zip/)
+            expect(result[:type]).to eq('application/zip')
+            expect(result[:is_file]).to be true
+          end
+        end
+
+        context 'when questions have images' do
+          let(:image) { double('Image') }
+          let(:images) { double('ActiveRecord::Associations::CollectionProxy', any?: true) }
+          let(:question_with_images) { build_stubbed(:question_traditional) }
+          let(:bookmark_with_images) { build_stubbed(:bookmark, user:, question: question_with_images) }
+          let(:service_with_images) { described_class.new([bookmark_with_images]) }
+          let(:temp_file) { Tempfile.new(['test', '.zip']) }
+          let(:zip_service) { instance_double(ZipFileService) }
+
+          before do
+            allow(question_with_images).to receive(:images).and_return(images)
+            # allow(images).to receive(:any?).and_return(true)
+            allow(ZipFileService).to receive(:new).and_return(zip_service)
+            allow(zip_service).to receive(:generate_zip).and_return(temp_file)
+          end
+
+          it 'returns a hash with a zip file' do
+            result = service_with_images.export('canvas')
+
+            expect(result[:data]).to eq(temp_file)
+            expect(result[:filename]).to match(/questions-canvas.*\.zip/)
+            expect(result[:type]).to eq('application/zip')
+            expect(result[:is_file]).to be true
+          end
+        end
+      end
+
+      context 'Blackboard' do
+        let(:formatter_klass) { QuestionFormatter::BlackboardService }
+
+        before do
+          allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('blackboard content')
+        end
+
+        it 'returns a hash with blackboard data' do
+          result = service.export('blackboard')
+
+          expect(result[:data]).to eq('blackboard content')
+          expect(result[:filename]).to match(/questions-blackboard.*\.txt/)
+          expect(result[:type]).to eq('text/plain')
+        end
+      end
+
+      context 'D2L' do
+        let(:formatter_klass) { QuestionFormatter::D2lService }
+
+        before do
+          allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('brightspace content')
+        end
+
+        it 'returns a hash with brightspace data' do
+          result = service.export('d2l')
+
+          expect(result[:data]).to eq('brightspace content')
+          expect(result[:filename]).to match(/questions-d2l.*\.zip/)
           expect(result[:type]).to eq('application/zip')
-          expect(result[:is_file]).to be true
+        end
+      end
+
+      context 'Moodle' do
+        let(:formatter_klass) { QuestionFormatter::MoodleService }
+
+        before do
+          allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('<xml>moodle content</xml>')
+        end
+
+        it 'returns a hash with brightspace data' do
+          result = service.export('moodle')
+
+          expect(result[:data]).to eq('<xml>moodle content</xml>')
+          expect(result[:filename]).to match(/questions-moodle.*\.xml/)
+          expect(result[:type]).to eq('text/xml')
         end
       end
     end
 
-    describe '#blackboard_export' do
-      let(:formatter_klass) { QuestionFormatter::BlackboardService }
-
-      before do
-        allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('blackboard content')
-      end
-
-      it 'returns a hash with blackboard data' do
-        result = service.export('blackboard')
-
-        expect(result[:data]).to eq('blackboard content')
-        expect(result[:filename]).to match(/questions-blackboard.*\.txt/)
-        expect(result[:type]).to eq('text/plain')
-      end
-    end
-
-    describe '#d2l_export' do
-      let(:formatter_klass) { QuestionFormatter::D2lService }
-
-      before do
-        allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('brightspace content')
-      end
-
-      it 'returns a hash with brightspace data' do
-        result = service.export('d2l')
-
-        expect(result[:data]).to eq('brightspace content')
-        expect(result[:filename]).to match(/questions-d2l.*\.zip/)
-        expect(result[:type]).to eq('application/zip')
-      end
-    end
-
-    describe '#moodle_export' do
-      let(:formatter_klass) { QuestionFormatter::MoodleService }
-
-      before do
-        allow_any_instance_of(formatter_klass).to receive(:format_content).and_return('<xml>moodle content</xml>')
-      end
-
-      it 'returns a hash with brightspace data' do
-        result = service.export('moodle')
-
-        expect(result[:data]).to eq('<xml>moodle content</xml>')
-        expect(result[:filename]).to match(/questions-moodle.*\.xml/)
-        expect(result[:type]).to eq('application/xml')
+    context 'when it is unsupported' do
+      it 'raises an error' do
+        expect { service.export('foo') }.to raise_error
       end
     end
   end

--- a/spec/services/bookmark_export_service_spec.rb
+++ b/spec/services/bookmark_export_service_spec.rb
@@ -153,8 +153,8 @@ RSpec.describe BookmarkExportService do
         result = service.export('d2l')
 
         expect(result[:data]).to eq('brightspace content')
-        expect(result[:filename]).to match(/questions-d2l.*\.csv/)
-        expect(result[:type]).to eq('text/csv')
+        expect(result[:filename]).to match(/questions-d2l.*\.zip/)
+        expect(result[:type]).to eq('application/zip')
       end
     end
 

--- a/spec/services/question_formatter/d2l_service_spec.rb
+++ b/spec/services/question_formatter/d2l_service_spec.rb
@@ -76,40 +76,65 @@ RSpec.describe QuestionFormatter::D2lService do
 
   describe '#format_content' do
     it 'handles essays' do
-      expect(described_class.new([essay_question]).format_content).to eq(formatted_essay_question)
-      expect(described_class.new([essay_question]).format_content).to be_a(String)
+      zip_file = described_class.new([essay_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        content = zip_entries.get_input_stream('questions.csv').read
+        expect(content).to eq(formatted_essay_question)
+        expect(content).to be_a(String)
+      end
     end
 
     it 'handles matching' do
-      expect(described_class.new([matching_question]).format_content).to eq(formatted_matching_question)
+      zip_file = described_class.new([matching_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        content = zip_entries.get_input_stream('questions.csv').read
+        expect(content).to eq(formatted_matching_question)
+      end
     end
 
     it 'handles select all that apply' do
-      expect(described_class.new([select_all_question]).format_content).to eq(formatted_select_all_question)
+      zip_file = described_class.new([select_all_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        content = zip_entries.get_input_stream('questions.csv').read
+        expect(content).to eq(formatted_select_all_question)
+      end
     end
 
     it 'handles traditional' do
-      expect(described_class.new([traditional_question]).format_content).to eq(formatted_traditional_question)
+      zip_file = described_class.new([traditional_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        content = zip_entries.get_input_stream('questions.csv').read
+        expect(content).to eq(formatted_traditional_question)
+      end
     end
 
     it 'handles uploads' do
-      expect(described_class.new([upload_question]).format_content).to eq(formatted_upload_question)
+      zip_file = described_class.new([upload_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        content = zip_entries.get_input_stream('questions.csv').read
+        expect(content).to eq(formatted_upload_question)
+      end
     end
 
     it 'does not handle other types' do
-      expect(described_class.new([unsupported_question]).format_content).to be_blank
+      zip_file = described_class.new([unsupported_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        content = zip_entries.get_input_stream('questions.csv').read
+        expect(content).to be_blank
+      end
     end
   end
 
   describe 'with images' do
-    let(:image) { double(:image, url: "/rails/active_storage/blobs/cat-injured.jpg") }
-
-    before do
-      allow(traditional_question).to receive(:images).and_return([image])
+    let(:traditional_question) do
+      create(:question_traditional, :with_images)
     end
 
     it 'includes the image URL' do
-      expect(described_class.new([traditional_question]).format_content).to include(image.url)
+      zip_file = described_class.new([traditional_question]).format_content
+      Zip::File.open(zip_file.path) do |zip_entries|
+        expect(zip_entries.map(&:name).any? { |name| name.include?('images') }).to eq true
+      end
     end
   end
 end

--- a/spec/services/zip_file_service_spec.rb
+++ b/spec/services/zip_file_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ZipFileService do
   describe '#generate_zip' do
     it 'creates a zip file with the xml content and images' do
       question = create(:question_bow_tie, :with_images)
-      temp_file = described_class.new(question.images, 'xml content', 'filename.xml').generate_zip
+      temp_file = described_class.new(question.images, 'xml content', 'filename.xml', 'questions').generate_zip
 
       Zip::File.open(temp_file.path) do |zipfile|
         expect(zipfile.entries.map(&:name)).to include('questions/filename.xml')


### PR DESCRIPTION
It's a two step process for D2L if we're including images.  The user must upload the images into their file system (we recommend /images/*). Then the user imports the CSV.  We've made the service output a zip file which has the CSV and images (if any).

Ref:
- https://github.com/notch8/viva/issues/414