### PR TITLE
🎁 Blackboard now exports images

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -17,4 +17,8 @@ class Image < ApplicationRecord
   def base64_encoded_data
     Base64.strict_encode64(file.download)
   end
+
+  def mime_type
+    file.blob.content_type
+  end
 end

--- a/app/services/question_formatter/blackboard_service.rb
+++ b/app/services/question_formatter/blackboard_service.rb
@@ -17,19 +17,19 @@ module QuestionFormatter
     end
 
     def traditional_type
-      @text = @question.text
+      @text = question_text
       @answers = @question.data.map do |data|
         [data['answer'], coherce_answer_mapper[data['correct'].to_s]].join("\t")
       end
     end
 
     def essay_type
-      @text = [@question.text, remove_newlines(@question.data['html'])].join('<br/>')
+      @text = [question_text, remove_newlines(@question.data['html'])].join('<br/>')
       @answers = '[Placeholder essay text]'
     end
 
     def matching_type
-      @text = @question.text
+      @text = question_text
       @answers = @question.data.map do |datum|
         [datum['answer'], datum['correct'].first].join("\t")
       end
@@ -44,6 +44,16 @@ module QuestionFormatter
 
     def remove_newlines(text)
       text.delete("\n")
+    end
+
+    def question_text
+      image_tag + @question.text
+    end
+
+    def image_tag
+      @question.images.map do |image|
+        "<img src=\"data:#{image.mime_type};base64,#{image.base64_encoded_data}\" alt=\"#{image.alt_text}\"><br/>"
+      end.join
     end
   end
 end

--- a/spec/services/question_formatter/blackboard_service_spec.rb
+++ b/spec/services/question_formatter/blackboard_service_spec.rb
@@ -86,5 +86,13 @@ RSpec.describe QuestionFormatter::BlackboardService do
         expect(subject.format_content).to be_blank
       end
     end
+
+    context 'when the question has images' do
+      let!(:question) { FactoryBot.create(:question_traditional, :with_images) }
+
+      it 'adds image tags to the text' do
+        expect(subject.format_content.scan("<img src=\"data:image/png").length).to eq(question.images.size)
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit will add logic to handle image exporting for Blackboard TSV text files.  We needed to base64 encode the binary of the image and add it into an <img> tag.

Ref:
- https://github.com/notch8/viva/issues/413