### PR TITLE
🎁 Add a step to pretty up the xml for canvas

### DIFF
--- a/app/services/question_formatter/canvas_service.rb
+++ b/app/services/question_formatter/canvas_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rexml/document'
+
 ##
 # Service to handle formatting questions into Canvas's dti format
 module QuestionFormatter
@@ -17,6 +19,8 @@ module QuestionFormatter
         assigns: { questions:, title: "Canvas Export #{Time.current.strftime('%B %-d, %Y')}" }
       )
 
+      xml_content = pretty_xml!(xml_content)
+
       xml_filename = 'questions.xml'
       images = questions.flat_map(&:images)
 
@@ -29,6 +33,17 @@ module QuestionFormatter
     end
 
     private
+
+    # Returns a pretty version of the xml input
+    def pretty_xml!(xml_content)
+      String.new.tap do |output|
+        REXML::Formatters::Pretty.new.tap do |formatter|
+          formatter.compact = true
+          formatter.width = Float::INFINITY
+          formatter.write(REXML::Document.new(xml_content), output)
+        end
+      end
+    end
 
     def add_manifest!(zip_file)
       Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip_entries|


### PR DESCRIPTION
This commit will add a step where we can make the XML a little prettier to look at.  Though this is very much a nice to have, it will serve us when we're trying to debug differences in XML for Canvas.

Before:
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/00582049-349c-4432-aec3-9b39075690fe" />

After:
<img width="1413" alt="image" src="https://github.com/user-attachments/assets/344f6529-03cd-4201-8876-209f9c418e18" />
