### PR TITLE
🐛 Account for return carriage

### DIFF
--- a/app/services/question_formatter/blackboard_service.rb
+++ b/app/services/question_formatter/blackboard_service.rb
@@ -24,7 +24,7 @@ module QuestionFormatter
     end
 
     def essay_type
-      @text = [question_text, remove_newlines(@question.data['html'])].join('<br/>')
+      @text = [question_text, scrub!(@question.data['html'])].join('<br/>')
       @answers = '[Placeholder essay text]'
     end
 
@@ -42,12 +42,12 @@ module QuestionFormatter
       }
     end
 
-    def remove_newlines(text)
-      text.delete("\n")
+    def question_text
+      image_tag + scrub!(@question.text)
     end
 
-    def question_text
-      image_tag + @question.text
+    def scrub!(text)
+      text.delete("\n").gsub("\r", '<br/><br/>')
     end
 
     def image_tag

--- a/spec/fixtures/files/bb_export.txt
+++ b/spec/fixtures/files/bb_export.txt
@@ -1,4 +1,4 @@
 MC	Which anime series features a young boy named Izuku Midoriya who dreams of becoming a superhero?	My Hero Academia	correct	Naruto	incorrect	One Piece	incorrect	Attack on Titan	incorrect
 MA	Which of the following anime studios produced films directed by Hayao Miyazaki?	Studio Ghibli	correct	Kyoto Animation	incorrect	Toei Animation	incorrect	Studio Ponoc	correct	Madhouse	incorrect
 ESS	Themes of friendship and perseverance<br/><div class="question-introduction">  <p>Analyze how themes of friendship are portrayed in shonen anime.</p><p>Include specific examples from the series.</p></div>	[Placeholder essay text]
-MAT	Match each anime character to their respective series	Spike Spiegel	Cowboy Bebop	Mikasa Ackerman	Attack on Titan	Edward Elric	Fullmetal Alchemist	Master Roshi	Dragon Ball
+MAT	Time for a matching question!<br/><br/>Match each anime character to their respective series	Spike Spiegel	Cowboy Bebop	Mikasa Ackerman	Attack on Titan	Edward Elric	Fullmetal Alchemist	Master Roshi	Dragon Ball

--- a/spec/services/bookmark_export_service_spec.rb
+++ b/spec/services/bookmark_export_service_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe BookmarkExportService do
 
     context 'when it is unsupported' do
       it 'raises an error' do
-        expect { service.export('foo') }.to raise_error
+        expect { service.export('foo') }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/services/question_formatter/blackboard_service_spec.rb
+++ b/spec/services/question_formatter/blackboard_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe QuestionFormatter::BlackboardService do
     context 'when it is Matching' do
       let(:question) do
         Question::Matching.new(
-          text: 'Match each anime character to their respective series',
+          text: "Time for a matching question!\r\nMatch each anime character to their respective series",
           data: [
             { 'answer' => 'Spike Spiegel', 'correct' => ['Cowboy Bebop'] },
             { 'answer' => 'Mikasa Ackerman', 'correct' => ['Attack on Titan'] },


### PR DESCRIPTION
## 🐛 Account for return carriage

99260887c68e87cf26dae49f7604592dc6e94319

This commit will account for the presence of return carriage characters
in the question.  If it has one then it will turn it into two <br/> tags
which will render correctly in Blackboard.

Ref:
- https://github.com/notch8/viva/issues/358

## 🧹 Pass Error to raise_error

77627b4733c77de6eeb6af37df07b6f36bac428c

This commit cleans up a WARNING from rspec to pass in the type of error
to the raise_error matcher.
