### PR TITLE
🐛 Prevents label change on the Question dropdown

### DIFF
--- a/app/javascript/components/ui/CreateQuestionForm/Bowtie.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Bowtie.jsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useRef } from 'react'
 import QuestionText from './QuestionText'
 import AnswerSet from './AnswerSet'
 
-const Bowtie = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const Bowtie = ({ handleTextChange, onDataChange, questionText, questionType,  resetFields }) => {
   const [centerAnswers, setCenterAnswers] = useState([])
   const [rightAnswers, setRightAnswers] = useState([])
   const [leftAnswers, setLeftAnswers] = useState([])
@@ -48,6 +48,7 @@ const Bowtie = ({ questionText, handleTextChange, onDataChange, resetFields }) =
 
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
       <AnswerSet
         resetFields={resetFields}

--- a/app/javascript/components/ui/CreateQuestionForm/Categorization.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Categorization.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Form, Button } from 'react-bootstrap'
 import QuestionText from './QuestionText'
 
-const Categorization = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const Categorization = ({ handleTextChange, onDataChange, questionText, questionType, resetFields }) => {
   const [categories, setCategories] = useState([{ answer: '', correct: [''] }])
 
   useEffect(() => {
@@ -64,6 +64,7 @@ const Categorization = ({ questionText, handleTextChange, onDataChange, resetFie
 
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
       <h6>Categorization</h6>
       {categories.map((category, index) => (

--- a/app/javascript/components/ui/CreateQuestionForm/DragAndDrop.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/DragAndDrop.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import QuestionText from './QuestionText'
 import AnswerSet from './AnswerSet'
 
-const DragAndDrop = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const DragAndDrop = ({ handleTextChange, onDataChange, questionText, questionType, resetFields }) => {
   const updateTimeout = useRef(null)
 
   const updateParent = useCallback((updatedAnswers) => {
@@ -26,6 +26,7 @@ const DragAndDrop = ({ questionText, handleTextChange, onDataChange, resetFields
 
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
       <AnswerSet
         resetFields={resetFields}

--- a/app/javascript/components/ui/CreateQuestionForm/Essay.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Essay.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import QuestionText from './QuestionText'
 
-const Essay = ({ handleSubmit, questionText, handleTextChange }) => {
+const Essay = ({ handleSubmit, handleTextChange, questionText, questionType}) => {
+
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText handleSubmit={ handleSubmit } questionText={ questionText } handleTextChange={ handleTextChange } />
     </>
   )

--- a/app/javascript/components/ui/CreateQuestionForm/Matching.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Matching.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Form, Button } from 'react-bootstrap'
 import QuestionText from './QuestionText'
 
-const Matching = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const Matching = ({ handleTextChange, onDataChange,questionText, questionType, resetFields }) => {
   const [pairs, setPairs] = useState([
     { answer: '', correct: '' },
     { answer: '', correct: '' },
@@ -45,6 +45,7 @@ const Matching = ({ questionText, handleTextChange, onDataChange, resetFields })
 
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
       <h6>Matching Pairs</h6>
       {pairs.map((pair, index) => (

--- a/app/javascript/components/ui/CreateQuestionForm/MultipleChoice.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/MultipleChoice.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import QuestionText from './QuestionText'
 import AnswerSet from './AnswerSet'
 
-const MultipleChoice = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const MultipleChoice = ({ handleTextChange, onDataChange, questionText, questionType, resetFields }) => {
   const updateTimeout = useRef(null)
 
   const updateParent = useCallback((updatedAnswers) => {
@@ -26,6 +26,7 @@ const MultipleChoice = ({ questionText, handleTextChange, onDataChange, resetFie
 
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
       <AnswerSet
         resetFields={resetFields}

--- a/app/javascript/components/ui/CreateQuestionForm/QuestionTypeDropdown.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/QuestionTypeDropdown.jsx
@@ -1,21 +1,17 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Dropdown, Form } from 'react-bootstrap'
 import CustomDropdown from '../CustomDropdown'
 
 const QuestionTypeDropdown = ({ handleQuestionTypeSelection, QUESTION_TYPE_NAMES }) => {
-  const [selectedQuestionType, setSelectedQuestionType] = useState('Select Question Type')
-
   const questionTypeDropdown = (questionType) => {
     handleQuestionTypeSelection(questionType)
-    setSelectedQuestionType(questionType)
   }
 
   return (
     <Form.Group controlId='questionType'>
-      <Form.Label>Select Question Type</Form.Label>
       <CustomDropdown dropdownSelector='.question-type-dropdown'>
         <Dropdown onSelect={questionTypeDropdown} className='question-type-dropdown'>
-          <Dropdown.Toggle variant='secondary'>{selectedQuestionType}</Dropdown.Toggle>
+          <Dropdown.Toggle variant='secondary'>Select Question Type</Dropdown.Toggle>
           <Dropdown.Menu>
             {QUESTION_TYPE_NAMES.map(({ key, value }) => (
               <Dropdown.Item key={key} eventKey={value}>

--- a/app/javascript/components/ui/CreateQuestionForm/SelectAllThatApply.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/SelectAllThatApply.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import QuestionText from './QuestionText'
 import AnswerSet from './AnswerSet'
 
-const SelectAllThatApply = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const SelectAllThatApply = ({ handleTextChange, onDataChange, questionType, questionText, resetFields }) => {
   const updateTimeout = useRef(null)
 
   const updateParent = useCallback((updatedAnswers) => {
@@ -26,6 +26,7 @@ const SelectAllThatApply = ({ questionText, handleTextChange, onDataChange, rese
 
   return (
     <>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
       <AnswerSet
         resetFields={resetFields}

--- a/app/javascript/components/ui/CreateQuestionForm/StimulusCaseStudy.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/StimulusCaseStudy.jsx
@@ -15,7 +15,7 @@ import Upload from './Upload'
 import QuestionTypeDropdown from './QuestionTypeDropdown'
 import QuestionText from './QuestionText'
 
-const StimulusCaseStudy = ({ questionText, handleTextChange, onDataChange, resetFields }) => {
+const StimulusCaseStudy = ({ handleTextChange, onDataChange, questionText, questionType, resetFields }) => {
   const [subQuestions, setSubQuestions] = useState([])
   const updateTimeout = useRef(null)
 
@@ -147,7 +147,7 @@ const StimulusCaseStudy = ({ questionText, handleTextChange, onDataChange, reset
 
   return (
     <div className='stimulus-case-study-form'>
-      <h3>Stimulus Case Study</h3>
+      <h3>{questionType} Question</h3>
       <QuestionText questionText={questionText} handleTextChange={handleTextChange} />
 
       <h4>Subquestions</h4>

--- a/app/javascript/components/ui/CreateQuestionForm/Upload.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/Upload.jsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import { Form } from 'react-bootstrap'
 
-const Upload = ({ questionText, handleTextChange }) => {
+const Upload = ({ handleTextChange, questionText, questionType }) => {
   return (
-    <Form.Group className='mb-3'>
-      <Form.Label>Question Text</Form.Label>
-      <Form.Control
-        as='textarea'
-        rows={3}
-        value={questionText}
-        onChange={handleTextChange}
-        placeholder='Enter your question text here...'
-      />
-    </Form.Group>
+    <>
+      <h3>{questionType} Question</h3>
+      <Form.Group className='mb-3'>
+        <Form.Label>Question Text</Form.Label>
+        <Form.Control
+          as='textarea'
+          rows={3}
+          value={questionText}
+          onChange={handleTextChange}
+          placeholder='Enter your question text here...'
+        />
+      </Form.Group>
+    </>
   )
 }
 

--- a/app/javascript/components/ui/CreateQuestionForm/index.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/index.jsx
@@ -298,9 +298,10 @@ const CreateQuestionForm = ({ subjectOptions }) => {
             <div className='d-flex flex-wrap'>
               <div className='flex-fill'>
                 <QuestionComponent
-                  questionText={questionText}
                   handleTextChange={handleTextChange}
                   onDataChange={setData}
+                  questionText={questionText}
+                  questionType={questionType}
                   resetFields={resetFields}
                 />
                 <ImageUploader images={images} setImages={setImages} />


### PR DESCRIPTION
# Story: [i335] Question Type Dropdown Label

Ref:
- https://github.com/notch8/viva/issues/335

## Expected Behavior Before Changes

On the Uploads page when a user selected a question type to create a single question via form, the dropdown menu button displayed the name of the selected question type. The name of the question type continued to be displayed on the button even after the question form was submitted.
This was the only label that determined which question form was being displayed.

## Expected Behavior After Changes

The dropdown menu label stays the same regardless of user interaction. The dropdown menu displays only "Select Question Type"
Each question form has its own heading displaying the question type.

## Screenshots / Video

<details>
<summary>Photo: Dropdown menu displaying "Select Question Type" and the question type heading on the given form</summary>

<img width="1250" alt="Screenshot 2025-03-13 at 4 08 00 PM" src="https://github.com/user-attachments/assets/0a1c1bad-cd0d-4f21-b4cb-f445f044cdab" />

</details>

## Notes

This was an issue that was reported internally by the Notch8 team.
