### PR TITLE
🐛 Adding the bookmark filtered back

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -8,6 +8,15 @@ class BookmarksController < ApplicationController
     handle_bookmark_action(@bookmark.save, '.success', '.failure')
   end
 
+  def create_batch
+    result = Bookmark.create_batch(question_ids: params[:filtered_ids], user: current_user)
+    if result == :error
+      redirect_back(fallback_location: authenticated_root_path, notice: t('.failure'))
+    else
+      redirect_back(fallback_location: authenticated_root_path, notice: t('.success'))
+    end
+  end
+
   def destroy
     handle_bookmark_action(@bookmark&.destroy, '.success', '.failure')
   end

--- a/app/javascript/components/ui/Search/SearchFilters.jsx
+++ b/app/javascript/components/ui/Search/SearchFilters.jsx
@@ -22,7 +22,7 @@ const SearchFilters = (props) => {
 
   const handleBookmarkBatch = () => {
     const filteredIds = filteredQuestions.map(question => question.id).join(',')
-    Inertia.post('/search/create_bookmarks', { filtered_ids: filteredIds }, {
+    Inertia.post('/bookmarks/create_batch', { filtered_ids: filteredIds }, {
       onSuccess: () => {
         console.log('Bookmarks added successfully')
       },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       # bookmarks page routes
       delete 'bookmarks/destroy_all', to: 'bookmarks#destroy_all' # has to come before bookmarks#destroy
       post 'bookmarks', to: 'bookmarks#create'
+      post '/bookmarks/create_batch', to: 'bookmarks#create_batch'
       delete 'bookmarks/:id', to: 'bookmarks#destroy', as: 'bookmark'
       get 'bookmarks/export', to: 'bookmarks#export'
       # create a question

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe BookmarksController do
     end
   end
 
+  describe '#create_batch' do
+    let(:question) { double('Question', id: '1') }
+    let(:question_ids) { [question.id] }
+
+    it 'creates a bookmark and redirects back with success notice' do
+      expect(Bookmark).to receive(:create_batch).with(question_ids:, user:)
+
+      post :create_batch, params: { filtered_ids: question_ids }
+    end
+  end
+
   describe '#destroy' do
     it 'deletes a bookmark for the current user' do
       question = FactoryBot.create(:question_traditional)


### PR DESCRIPTION
This commit will revert a removal for the bookmark filtered search. Turns out this was indeed being used still.