### PR TITLE
🐛 Console errors on questions with checkboxes

### DIFF
--- a/app/javascript/components/ui/CreateQuestionForm/AnswerField.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/AnswerField.jsx
@@ -16,23 +16,9 @@ const AnswerField = ({ answers, updateAnswer, removeAnswer, title, buttonType = 
           />
           <Form.Check
             type={buttonType}
+            name={buttonType === 'radio' ? 'correctAnswerGroup' : `checkbox-${index}`}
             checked={answer.correct}
-            onClick={() => {
-              if (buttonType === 'radio') {
-                if (answer.correct) {
-                  // Deselect the current radio button
-                  updateAnswer(index, 'correct', false)
-                } else {
-                  // Ensure no other radio button is selected before selecting this one
-                  if (!answers.some(a => a.correct)) {
-                    updateAnswer(index, 'correct', true)
-                  }
-                }
-              } else if (buttonType === 'checkbox') {
-                // Toggle the checkbox state
-                updateAnswer(index, 'correct', !answer.correct)
-              }
-            }}
+            onChange={() => updateAnswer(index, 'correct', !answer.correct)}
             label='Correct'
           />
           <Button

--- a/app/javascript/components/ui/CreateQuestionForm/AnswerSet.jsx
+++ b/app/javascript/components/ui/CreateQuestionForm/AnswerSet.jsx
@@ -6,12 +6,14 @@ import { Plus } from '@phosphor-icons/react'
 import AnswerField from './AnswerField'
 
 const AnswerSet = ({ resetFields, getAnswerSet, title, multipleCorrectAnswers, numberOfDisplayedAnswers = 1 }) => {
+
   const initialAnswers = useMemo(
     () => Array.from({ length: numberOfDisplayedAnswers }, () => ({ answer: '', correct: false })),
     [numberOfDisplayedAnswers]
   )
 
   const [answers, setAnswers] = useState(initialAnswers)
+
   const debounceTimeout = useRef(null)
 
   useEffect(() => {
@@ -39,12 +41,24 @@ const AnswerSet = ({ resetFields, getAnswerSet, title, multipleCorrectAnswers, n
   }, [answers, notifyParent])
 
   const updateAnswer = useCallback((index, field, value) => {
-    const updatedAnswers = answers.map((answer, i) =>
-      i === index ? { ...answer, [field]: value } : answer
-    )
+    let updatedAnswers
+
+    if (field === 'correct' && value === true && !multipleCorrectAnswers) {
+      // For radio buttons (single correct answer), only one can be true at a time
+      updatedAnswers = answers.map((answer, i) => ({
+        ...answer,
+        correct: i === index // Only the selected one is correct
+      }))
+    } else {
+      // For text changes or checkbox changes
+      updatedAnswers = answers.map((answer, i) =>
+        i === index ? { ...answer, [field]: value } : answer
+      )
+    }
+
     setAnswers(updatedAnswers)
     notifyParent(updatedAnswers)
-  }, [answers, notifyParent])
+  }, [answers, multipleCorrectAnswers, notifyParent])
 
   const removeAnswer = useCallback((index) => {
     const updatedAnswers = answers.filter((_, i) => i !== index)


### PR DESCRIPTION
# Story: [i330] Console Errors on Question Upload Forms

Ref:
- https://github.com/notch8/viva/issues/330

## Expected Behavior Before Changes

Console errors occurred when creating question types that used a radio button or checkbox.

## Expected Behavior After Changes

This commit fixes the console errors that were appearing on the question form when the question type used checkboxes. The errors were due to an onClick action being used rather than the React-preferred onChange.

