### PR TITLE
🎁 Canvas exports to New and Classic platforms

### DIFF
--- a/app/javascript/components/ui/Export/Export.css
+++ b/app/javascript/components/ui/Export/Export.css
@@ -8,7 +8,7 @@
 
 .export-button {
   width: 100%;
-  height: 120px;
+  height: 140px;
   border: 1px solid #0d6efd;
   border-radius: 4px;
   display: flex;

--- a/app/javascript/components/ui/Export/ExportButton.cy.jsx
+++ b/app/javascript/components/ui/Export/ExportButton.cy.jsx
@@ -6,15 +6,23 @@ describe('<ExportButton />', () => {
     cy.mount(<ExportButton format='blackboard' label='Blackboard' questionTypes={[]} hasBookmarks={false} />)
   })
 
-  it('displays correct tooltip text for empty questionTypes array', () => {
-    cy.mount(<ExportButton format='blackboard' label='Blackboard' questionTypes={[]} hasBookmarks={false} />)
-    cy.get('.export-button').trigger('mouseover')
-    cy.get('.tooltip-inner').should('contain', 'Supports all question types in plain text format')
+  it('displays "All Question Types Supported" for text formats', () => {
+    // Test with markdown format
+    cy.mount(<ExportButton format='md' label='Markdown' questionTypes={[]} hasBookmarks={false} />)
+    cy.get('.supported-types').should('contain', 'All Question Types Supported')
+
+    // Test with txt format
+    cy.mount(<ExportButton format='txt' label='Text' questionTypes={[]} hasBookmarks={false} />)
+    cy.get('.supported-types').should('contain', 'All Question Types Supported')
   })
 
-  it('displays correct tooltip text for non-empty questionTypes array', () => {
-    cy.mount(<ExportButton format='blackboard' label='Blackboard' questionTypes={['Type1', 'Type2']} hasBookmarks={false} />)
-    cy.get('.export-button').trigger('mouseover')
-    cy.get('.tooltip-inner').should('contain', 'Supports: Type1, Type2')
+  it('displays supported question types for non-text formats', () => {
+    const questionTypes = ['Multiple Choice', 'Short Answer']
+    cy.mount(<ExportButton format='blackboard' label='Blackboard' questionTypes={questionTypes} hasBookmarks={false} />)
+
+    // Check that each question type is displayed
+    questionTypes.forEach(type => {
+      cy.get('.supported-types').should('contain', type)
+    })
   })
 })

--- a/app/javascript/components/ui/Export/ExportModal.cy.jsx
+++ b/app/javascript/components/ui/Export/ExportModal.cy.jsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import {
+  Modal, Button, Tabs, Tab
+} from 'react-bootstrap'
+import ExportButton from './ExportButton'
+
+// Create a test version of ExportModal that doesn't use Inertia
+const TestExportModal = ({ show, onHide, hasBookmarks }) => {
+  const mockLms = {
+    canvas: ['Categorization (New only)', 'Essay', 'File Upload', 'Matching', 'Multiple Choice', 'SelectAll That Apply'],
+    blackboard: ['Essay', 'Matching', 'Multiple Choice', 'SelectAll That Apply'],
+    d2l: ['Essay', 'File Upload', 'Matching', 'Multiple Choice', 'SelectAll That Apply'],
+    moodle: ['Essay', 'Matching', 'Multiple Choice', 'SelectAll That Apply']
+  }
+
+  return (
+    <Modal show={show} onHide={onHide} size='lg' centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Export Bookmarked Questions</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Tabs defaultActiveKey='lms' className='mb-3'>
+          <Tab eventKey='lms' title='Learning Management Systems'>
+            <div className='d-flex justify-content-between flex-wrap'>
+              <ExportButton format='canvas' label='Canvas (New & Classic)' questionTypes={mockLms.canvas} hasBookmarks={hasBookmarks} />
+              <ExportButton format='blackboard' label='Blackboard' questionTypes={mockLms.blackboard} hasBookmarks={hasBookmarks} />
+              <ExportButton format='d2l' label='Brightspace (D2L)' questionTypes={mockLms.d2l} hasBookmarks={hasBookmarks} />
+              <ExportButton format='moodle' label='Moodle' questionTypes={mockLms.moodle} hasBookmarks={hasBookmarks} />
+            </div>
+          </Tab>
+          <Tab eventKey='text' title='Text Formats'>
+            <div className='d-flex justify-content-center'>
+              <ExportButton format='md' label='Markdown' questionTypes={[]} hasBookmarks={hasBookmarks} />
+              <ExportButton format='txt' label='Plain Text' questionTypes={[]} hasBookmarks={hasBookmarks} />
+            </div>
+          </Tab>
+        </Tabs>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant='secondary' onClick={onHide}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}
+
+describe('<ExportModal />', () => {
+  const mountComponent = (props = {}) => {
+    const defaultProps = {
+      show: true,
+      onHide: cy.stub().as('onHide'),
+      hasBookmarks: true
+    }
+
+    cy.mount(
+      <TestExportModal {...Object.assign({}, defaultProps, props)} />
+    )
+  }
+
+  it('renders when show is true', () => {
+    mountComponent()
+    cy.get('.modal').should('be.visible')
+    cy.get('.modal-title').should('contain', 'Export Bookmarked Questions')
+  })
+
+  it('does not render when show is false', () => {
+    mountComponent({ show: false })
+    cy.get('.modal').should('not.exist')
+  })
+
+  it('calls onHide when close button is clicked', () => {
+    mountComponent()
+    cy.get('.modal-header .btn-close').click()
+    cy.get('@onHide').should('have.been.called')
+  })
+
+  it('calls onHide when Close button in footer is clicked', () => {
+    mountComponent()
+    cy.get('.modal-footer .btn-secondary').click()
+    cy.get('@onHide').should('have.been.called')
+  })
+
+  it('displays the LMS tab by default', () => {
+    mountComponent()
+    cy.get('.nav-tabs .active').should('contain', 'Learning Management Systems')
+    cy.get('[data-format="canvas"]').should('be.visible')
+    cy.get('[data-format="blackboard"]').should('be.visible')
+    cy.get('[data-format="d2l"]').should('be.visible')
+    cy.get('[data-format="moodle"]').should('be.visible')
+  })
+
+  it('switches to Text Formats tab when clicked', () => {
+    mountComponent()
+    cy.get('.nav-tabs').contains('Text Formats').click()
+    cy.get('.nav-tabs .active').should('contain', 'Text Formats')
+    cy.get('[data-format="md"]').should('be.visible')
+    cy.get('[data-format="txt"]').should('be.visible')
+  })
+
+  it('displays correct question types for Canvas', () => {
+    mountComponent()
+    cy.get('[data-format="canvas"]').closest('.export-button-container')
+      .find('.supported-types')
+      .should('contain', 'Categorization (New only)')
+      .should('contain', 'Essay')
+      .should('contain', 'File Upload')
+      .should('contain', 'Matching')
+      .should('contain', 'Multiple Choice')
+      .should('contain', 'SelectAll That Apply')
+  })
+
+  it('displays correct question types for Blackboard', () => {
+    mountComponent()
+    cy.get('[data-format="blackboard"]').closest('.export-button-container')
+      .find('.supported-types')
+      .should('contain', 'Essay')
+      .should('contain', 'Matching')
+      .should('contain', 'Multiple Choice')
+      .should('contain', 'SelectAll That Apply')
+  })
+
+  it('displays correct question types for D2L Brightspace', () => {
+    mountComponent()
+    cy.get('[data-format="d2l"]').closest('.export-button-container')
+      .find('.supported-types')
+      .should('contain', 'Essay')
+      .should('contain', 'Matching')
+      .should('contain', 'Multiple Choice')
+      .should('contain', 'SelectAll That Apply')
+  })
+
+  it('displays correct question types for Moodle', () => {
+    mountComponent()
+    cy.get('[data-format="moodle"]').closest('.export-button-container')
+      .find('.supported-types')
+      .should('contain', 'Essay')
+      .should('contain', 'Matching')
+      .should('contain', 'Multiple Choice')
+      .should('contain', 'SelectAll That Apply')
+  })
+
+  it('enables export buttons when hasBookmarks is true', () => {
+    mountComponent({ hasBookmarks: true })
+    cy.get('.export-button').should('not.have.attr', 'disabled')
+  })
+
+  it('disables export buttons when hasBookmarks is false', () => {
+    mountComponent({ hasBookmarks: false })
+    cy.get('[data-format="canvas"]').should('have.attr', 'disabled')
+    cy.get('[data-format="blackboard"]').should('have.attr', 'disabled')
+    cy.get('[data-format="d2l"]').should('have.attr', 'disabled')
+    cy.get('[data-format="moodle"]').should('have.attr', 'disabled')
+
+    cy.get('.nav-tabs').contains('Text Formats').click()
+    cy.get('[data-format="md"]').should('have.attr', 'disabled')
+    cy.get('[data-format="txt"]').should('have.attr', 'disabled')
+  })
+})

--- a/app/javascript/components/ui/Export/ExportModal.jsx
+++ b/app/javascript/components/ui/Export/ExportModal.jsx
@@ -8,6 +8,7 @@ import ExportButton from './ExportButton'
 
 const ExportModal = ({ show, onHide, hasBookmarks }) => {
   const lms = usePage().props.lms
+  const canvas = lms.canvas.map(type => type === 'Categorization' ? 'Categorization (New only)' : type)
 
   return (
     <Modal show={show} onHide={onHide} size='lg' centered>
@@ -17,8 +18,8 @@ const ExportModal = ({ show, onHide, hasBookmarks }) => {
       <Modal.Body>
         <Tabs defaultActiveKey='lms' className='mb-3'>
           <Tab eventKey='lms' title='Learning Management Systems'>
-            <div className='d-flex justify-content-between'>
-              <ExportButton format='canvas' label='Canvas' questionTypes={lms.canvas} hasBookmarks={hasBookmarks} />
+            <div className='d-flex justify-content-between flex-wrap'>
+              <ExportButton format='canvas' label='Canvas (New & Classic)' questionTypes={canvas} hasBookmarks={hasBookmarks} />
               <ExportButton format='blackboard' label='Blackboard' questionTypes={lms.blackboard} hasBookmarks={hasBookmarks} />
               <ExportButton format='d2l' label='Brightspace (D2L)' questionTypes={lms.d2l} hasBookmarks={hasBookmarks} />
               <ExportButton format='moodle' label='Moodle' questionTypes={lms.moodle} hasBookmarks={hasBookmarks} />

--- a/spec/fixtures/files/imsmanifest.xml
+++ b/spec/fixtures/files/imsmanifest.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest>
+<manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1" xmlns:lom="http://ltsc.ieee.org/xsd/imsccv1p1/LOM/resource" xmlns:imsmd="http://www.imsglobal.org/xsd/imsmd_v1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="quiz-export" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1 http://www.imsglobal.org/xsd/imscp_v1p1.xsd">
+  <metadata>
+    <schema>IMS Content</schema>
+    <schemaversion>1.1.3</schemaversion>
+  </metadata>
   <resources>
-    <resource>
+    <resource identifier="quiz-resource" type="imsqti_xmlv1p2">
       <file href="questions/questions.xml"/>
     </resource>
-    <resource>
+    <resource identifier="media-test_image_1" type="webcontent">
       <file href="questions/images/test_image_1.png"/>
     </resource>
-    <resource>
+    <resource identifier="media-test_image_2" type="webcontent">
       <file href="questions/images/test_image_2.png"/>
     </resource>
-    <resource>
+    <resource identifier="media-test_image_3" type="webcontent">
       <file href="questions/images/test_image_3.png"/>
     </resource>
   </resources>

--- a/spec/services/question_formatter/canvas_service_spec.rb
+++ b/spec/services/question_formatter/canvas_service_spec.rb
@@ -4,18 +4,23 @@ require 'rails_helper'
 
 RSpec.describe QuestionFormatter::CanvasService do
   subject { described_class.new([question]).format_content }
+  let(:service) { described_class.new([question]) }
 
   describe '#format_content' do
     context 'with images' do
       let!(:question) { create(:question_essay, :with_images) }
-      let(:manifest) { Rails.root.join('spec', 'fixtures', 'files', 'imsmanifest.xml').read }
+      let(:fixture_xml) { Rails.root.join('spec', 'fixtures', 'files', 'imsmanifest.xml').read }
 
       it 'produces a manifest file' do
-        expect(
-          Zip::File.open(subject) do |zip|
-            zip.get_input_stream('imsmanifest.xml').read
-          end
-        ).to eq(manifest)
+        generated_xml = Zip::File.open(subject) do |zip|
+          zip.get_input_stream('imsmanifest.xml').read
+        end
+
+        # Use the service's pretty_xml! method to normalize both XMLs
+        normalized_generated = service.send(:pretty_xml!, generated_xml)
+        normalized_fixture = service.send(:pretty_xml!, fixture_xml)
+
+        expect(normalized_generated).to eq(normalized_fixture)
       end
     end
   end


### PR DESCRIPTION
# Story: [i400] Upload to New and Classic Canvas

Ref:
- https://github.com/notch8/viva/issues/400

## Expected Behavior Before Changes

The Canvas export could only be imported to the Classic platform.

## Expected Behavior After Changes

The Canvas export is uploadable to New and Classic Canvas.

## Screenshots / Video

<details>
<summary>Photo: Export modal</summary>

<img width="1067" alt="Screenshot 2025-03-18 at 2 52 31 PM" src="https://github.com/user-attachments/assets/406ef364-a51f-4993-8db6-6fd18aed2dd5" />

</details>

## Notes

The New Canvas functionality was tested by Lisa at VIVA.

<img width="903" alt="Screenshot 2025-03-18 at 2 50 48 PM" src="https://github.com/user-attachments/assets/6b233f80-d9e4-48b7-ba5c-dabb8d41d84a" />

This zip was successfully uploaded to New Quiz by Lisa:

[questions-canvas-2025-03-18_19_45_08_185.zip](https://github.com/user-attachments/files/19328735/questions-canvas-2025-03-18_19_45_08_185.zip)

