### PR TITLE
:gear: Switch friends to development env

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -51,7 +51,7 @@ env:
     DATABASE_NAME: viva-friends
     DATABASE_PASSWORD: $DATABASE_PASSWORD
     DATABASE_USER: postgres
-    RAILS_ENV: production
+    RAILS_ENV: development
     RAILS_SERVE_STATIC_FILES: true
     RAILS_LOG_TO_STDOUT: true
     SECRET_KEY_BASE: $SECRET_KEY_BASE


### PR DESCRIPTION
This should enable clients to access /letter_opener to verify emails sent.

Issue: 
- https://github.com/notch8/viva/issues/477

