### PR TITLE
🧹 Update seeds file with admin and active set to true

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,11 @@ abort "Don't run this in production" if Rails.env.production?
 if ENV['DEFAULT_USER_EMAIL'] && ENV['DEFAULT_USER_PASSWORD']
   u = User.find_or_create_by(email: ENV['DEFAULT_USER_EMAIL']) do |u|
     u.password = ENV['DEFAULT_USER_PASSWORD']
+    u.admin = true
+    u.active = true
   end
+  # Update existing user if it already exists
+  u.update(admin: true, active: true) if u.persisted?
 end
 
 


### PR DESCRIPTION
Updated the seed file to set admin: true and active: true for the default user.

- When creating a new user: The block sets admin: true and active: true during creation.
- When the user already exists: The update call ensures an existing user is updated with these attributes.

This ensures the default user always has admin privileges and is active, whether it's newly created or already exists in the database.