### PR TITLE
:broom: [i478] Style Devise invitation password page

### DIFF
--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,56 @@
+<%# OVERRIDE Devise Invitations Edit template to apply Viva inline styles %>
+
+<main class='container d-flex justify-content-center align-items-center vh-100'>
+  <% if flash.any? %>
+    <div class="position-fixed top-0 end-0 p-3" style="z-index: 11">
+      <% flash.each do |type, message| %>
+        <div class="alert alert-<%= type == 'notice' ? 'info' : 'danger' %> alert-dismissible fade show" role="alert">
+          <%= message %>
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <div class='row justify-content-center w-100'>
+    <figure class='logo mt-5 mt-md-0'>
+      <%= image_tag('logo.png',
+        alt: 'Viva Logo',
+        class: 'img w-75 mx-auto d-block',
+        data: { title: 'Viva Logo' })
+      %>
+    </figure>
+    <div class='col-12 col-md-6 col-lg-4 p-5 bg-light rounded d-flex flex-column justify-content-center'>
+      <h2 class='text-primary mb-4'><%= t "devise.invitations.edit.header" %></h2>
+      
+      <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, class: 'w-100' }) do |f| %>
+        <%= f.hidden_field :invitation_token, readonly: true %>
+
+        <% if resource.errors.any? %>
+          <div class="alert alert-danger" role="alert">
+            <ul class="mb-0">
+              <% resource.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <% if f.object.class.require_password_on_accepting %>
+          <div class='field mt-3'>
+            <%= f.label :password, class: 'form-label' %>
+            <%= f.password_field :password, autocomplete: 'new-password', placeholder: 'Password', class: 'bg-secondary-subtle rounded border-0 w-100 p-2' %>
+          </div>
+
+          <div class='field mt-3'>
+            <%= f.label :password_confirmation, class: 'form-label' %>
+            <%= f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: 'Password confirmation', class: 'bg-secondary-subtle rounded border-0 w-100 p-2' %>
+          </div>
+        <% end %>
+
+        <div class='actions mt-4 d-flex justify-content-center'>
+          <%= f.submit t("devise.invitations.edit.submit_button"), class: 'btn btn-primary w-100' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION


Update the "Set your password" page to use the same layout and styling as the login page, including centered container, logo, primary-colored heading, and consistent form input styling.

Issue:
- https://github.com/notch8/viva/issues/478

# BEFORE

<img width="1632" height="593" alt="image" src="https://github.com/user-attachments/assets/c6d8fcdc-c9af-4afb-8cc3-a88e6e279fae" />


# AFTER

<img width="1920" height="942" alt="image" src="https://github.com/user-attachments/assets/31b4e280-faed-4d0c-9017-970f8ea8864d" />
