### PR TITLE
fixes staging create user issue

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,10 +69,24 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Use letter_opener in production if ENABLE_LETTER_OPENER is set
-  # temp solution to enable letter_opener for friends which has RAILS_ENV set to production
+  # Needed for Devise (and other mailers) to generate absolute URLs in emails.
+  # Example env overrides:
+  # - APP_HOST=viva-friends.notch8.cloud
+  # - APP_PROTOCOL=https
+  # - APP_PORT=443 (usually omit)
+  app_host = ENV.fetch('APP_HOST', 'viva-friends.notch8.cloud')
+  app_protocol = ENV.fetch('APP_PROTOCOL', 'https')
+  app_port = ENV['APP_PORT']
+  default_url_options = { host: app_host, protocol: app_protocol }
+  default_url_options[:port] = app_port if app_port.present?
+  config.action_mailer.default_url_options = default_url_options
+  config.action_controller.default_url_options = default_url_options
+
+  # Use letter_opener_web in production if ENABLE_LETTER_OPENER is set.
+  # This enables an admin-only email viewer at /letter_opener without requiring Launchy (a local browser),
+  # which is not available in typical production/container environments.
   if ENV['ENABLE_LETTER_OPENER'].present?
-    config.action_mailer.delivery_method = :letter_opener
+    config.action_mailer.delivery_method = :letter_opener_web
     config.action_mailer.perform_deliveries = true
   end
 

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -52,6 +52,9 @@ env:
     DATABASE_PASSWORD: $DATABASE_PASSWORD
     DATABASE_USER: postgres
     RAILS_ENV: production
+    # URL configuration for email links (used by Devise and other mailers)
+    APP_HOST: viva-friends.notch8.cloud
+    APP_PROTOCOL: https
     # Enable letter_opener_web for client demos (admin-only access at /letter_opener)
     # To disable for real production: remove this line or set to empty string
     ENABLE_LETTER_OPENER: "true"


### PR DESCRIPTION
Follow up on: 
- https://github.com/notch8/viva/pull/484/changes

Creating a new user previously caused this error because default_url_options weren't set in "prod" (aka friends): 

<img width="1727" height="284" alt="image" src="https://github.com/user-attachments/assets/45c64ef4-0d67-4ea4-b28b-3149b0ebca66" />


Proof that it no longer does and correctly sends the email when this branch is deployed to friends: 

<img width="1807" height="546" alt="image" src="https://github.com/user-attachments/assets/cbe53b98-9448-4d9f-af22-3667ab3a438c" />


<img width="1402" height="415" alt="image" src="https://github.com/user-attachments/assets/5f60d804-00dc-4707-9c3b-52b2215435af" />

