### PR TITLE
🎁 Text change on Admin column header and values

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -7,6 +7,8 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
+    helper AdministrateHelper
+
     before_action :authenticate_admin
 
     def authenticate_admin

--- a/app/helpers/administrate_helper.rb
+++ b/app/helpers/administrate_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module AdministrateHelper
+  def humanize_user_role(user)
+    user.admin? ? "\nAdmin\n" : "\nUser\n"
+  end
+end

--- a/app/views/admin/application/_collection.html.erb
+++ b/app/views/admin/application/_collection.html.erb
@@ -1,0 +1,112 @@
+<%#
+# OVERRIDE Administrate generated view to update the Admin column header to 'Role'
+and to update the Admin column value to 'Admin' or 'User' rather than 'true' or 'false'
+# rails generate administrate:views:index
+
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>" data-controller="table" data-action="click->table#visitDataUrl keydown->table#visitDataUrl">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+          cell-label--<%= attr_type.html_class %>
+          cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+          cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
+          scope="col"
+          <% if attr_type.sortable? %>
+            aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>"
+          <% end %>
+        >
+          <% if attr_type.sortable? %>
+            <%= link_to(params: sanitized_order_params(page, collection_field_name).merge(
+              collection_presenter.order_params_for(attr_name, key: collection_field_name)
+            )) do %>
+              <%# OVERRIDE begin %>
+              <%= attr_name == :admin && collection_presenter.resource_name == 'user' ? 'Role' : t(
+                "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+                default: resource_class.human_attribute_name(attr_name).titleize,
+              ) %>
+              <%# OVERRIDE end %>
+              <% if collection_presenter.ordered_by?(attr_name) %>
+                <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                  <svg aria-hidden="true">
+                    <use xlink:href="#icon-up-caret" />
+                  </svg>
+                </span>
+              <% end %>
+            <% end %>
+          <% else %>
+            <%# OVERRIDE begin %>
+            <%= attr_name == :admin && collection_presenter.resource_name == 'user' ? 'Role' : t(
+              "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+              default: resource_class.human_attribute_name(attr_name).titleize,
+            ) %>
+            <%# OVERRIDE end %>
+          <% end %>
+        </th>
+      <% end %>
+      <%= render(
+        "collection_header_actions",
+        collection_presenter: collection_presenter,
+        page: page,
+        resources: resources,
+        table_title: "page-title"
+      ) %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          <% if accessible_action?(resource, :show) %>
+            <%= %(tabindex=0 data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if accessible_action?(resource, :show) -%>
+              <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 tabindex="-1"
+                 class="action-show"
+                 >
+                <%# OVERRIDE begin %>
+                <%= attribute.attribute == :admin ? humanize_user_role(resource) : render_field(attribute) %>
+                <%# OVERRIDE end %>
+              </a>
+            <% else %>
+              <%= render_field attribute %>
+            <% end -%>
+          </td>
+        <% end %>
+
+        <%= render(
+          "collection_item_actions",
+          collection_presenter: collection_presenter,
+          collection_field_name: collection_field_name,
+          page: page,
+          namespace: namespace,
+          resource: resource,
+          table_title: "page-title"
+        ) %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -1,5 +1,7 @@
 <%#
 # OVERRIDE Administrate generated view to add a button to resend an invitation
+and to update the Admin column header to 'Role'
+and to update the Admin column value to 'Admin' or 'User' rather than 'true' or 'false'
 # rails generate administrate:views:show
 
 # Show
@@ -71,14 +73,18 @@ as well as a link to its edit page.
 
           <% attributes.each do |attribute| %>
             <dt class="attribute-label" id="<%= attribute.name %>">
-            <%= t(
-              "helpers.label.#{resource_name}.#{attribute.name}",
-              default: page.resource.class.human_attribute_name(attribute.name),
-            ) %>
+            <%# OVERRIDE begin %>
+            <%= attribute.name == 'admin' && page.resource_name == 'user' ? 'Role' : t(
+                "helpers.label.#{resource_name}.#{attribute.name}",
+                default: page.resource.class.human_attribute_name(attribute.name),
+              ) %>
+            <%# OVERRIDE end %>
             </dt>
 
+            <%# OVERRIDE begin %>
             <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-                ><%= render_field attribute, page: page %></dd>
+                ><%= attribute.name == 'admin' && page.resource_name == 'user' ? humanize_user_role(page.resource) : render_field(attribute, page: page) %></dd>
+            <%# OVERRIDE end %>
           <% end %>
         </fieldset>
       <% end %>


### PR DESCRIPTION
# Story: [i504] Text change on Admin column header and values

Ref:
- https://github.com/notch8/viva/issues/504

## Expected Behavior Before Changes

Admin index and show pages have an Admin column with true/false values

## Expected Behavior After Changes

Admin index and show pages have a Role column with Admin/User values

## Screenshots / Video

<details>
<summary>Index</summary>

<img width="1599" height="615" alt="Screenshot 2026-01-08 at 3 46 48 PM" src="https://github.com/user-attachments/assets/19362369-405f-4f67-a3dd-1d156a249970" />

</details>
<details>
<summary>Show: User</summary>

<img width="1590" height="651" alt="Screenshot 2026-01-08 at 3 46 41 PM" src="https://github.com/user-attachments/assets/0bf509a6-df17-4619-8cac-0f818ae92c05" />

</details>
<details>
<summary>Show: Admin</summary>

<img width="1604" height="624" alt="Screenshot 2026-01-08 at 3 46 54 PM" src="https://github.com/user-attachments/assets/4adf643f-ab5a-433b-b9c9-03d6ddf6a944" />

</details>
