### PR TITLE
🎁 Expose Question ID on UI and make it searchable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'devise_invitable'
 gem 'factory_bot', '~> 6.2'
 gem 'factory_bot_rails', group: %i[development test]
 gem 'faker', '~> 2.23'
+gem 'hashid-rails'
 gem 'inertia_rails', '~> 3.0'
 gem 'jbuilder' # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,10 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashid-rails (1.4.1)
+      activerecord (>= 4.0)
+      hashids (~> 1.0)
+    hashids (1.0.6)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     inertia_rails (3.1.2)
@@ -192,6 +196,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.20.0)
     msgpack (1.7.2)
     net-imap (0.4.3)
@@ -204,6 +209,9 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
@@ -416,6 +424,7 @@ DEPENDENCIES
   factory_bot (~> 6.2)
   factory_bot_rails
   faker (~> 2.23)
+  hashid-rails
   inertia_rails (~> 3.0)
   jbuilder
   jquery-rails

--- a/app/javascript/components/ui/Question/QuestionMetadata.jsx
+++ b/app/javascript/components/ui/Question/QuestionMetadata.jsx
@@ -83,7 +83,7 @@ const QuestionMetadata = ({ question, bookmarkedQuestionIds }) => {
           ))}
         </>
       }
-      <div className='d-flex mx-1 text-center mt-5'>
+      <div className='d-flex mx-1 text-center mt-5 mb-2'>
         <Col className='bg-white rounded-start p-2'>
           <h6 className='fw-bold'>Level</h6>
           <span className='strait small'>{question.level}</span>
@@ -93,6 +93,7 @@ const QuestionMetadata = ({ question, bookmarkedQuestionIds }) => {
           <span className='strait small'>{question.type_name}</span>
         </Col>
       </div>
+      <small className='text-muted ps-1'>Question ID: {question.hashid}</small>
     </div>
   )
 }

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe SearchController do
                  "subject_names" => question.subjects.names,
                  "alt_texts" => [],
                  "images" => [],
-                 "user_id" => question.user_id
+                 "user_id" => question.user_id,
+                 "hashid" => question.hashid
                }
              ])
         )
@@ -61,7 +62,8 @@ RSpec.describe SearchController do
                  "subject_names" => question1.subjects.names,
                  "alt_texts" => [],
                  "images" => [],
-                 "user_id" => question1.user_id
+                 "user_id" => question1.user_id,
+                 "hashid" => question1.hashid
                },
                {
                  "id" => question2.id,
@@ -75,7 +77,8 @@ RSpec.describe SearchController do
                  "subject_names" => question2.subjects.names,
                  "alt_texts" => [],
                  "images" => [],
-                 "user_id" => question2.user_id
+                 "user_id" => question2.user_id,
+                 "hashid" => question2.hashid
                }
              ])
         )
@@ -107,7 +110,8 @@ RSpec.describe SearchController do
                  "subject_names" => question1.subjects.names,
                  "alt_texts" => [],
                  "images" => [],
-                 "user_id" => question1.user_id
+                 "user_id" => question1.user_id,
+                 "hashid" => question1.hashid
                }
              ])
         )

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe Question, type: :model do
               subject_names: question1.subjects.names,
               images: [],
               alt_texts: [],
-              user_id: question1.user_id }.stringify_keys])
+              user_id: question1.user_id,
+              hashid: question1.hashid }.stringify_keys])
       )
     end
     # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
This commit will add the Question ID to the UI under the level and type metadata section.  The ID is also now searchable.

Ref
- https://github.com/notch8/viva/issues/472

<img width="3372" height="2463" alt="image" src="https://github.com/user-attachments/assets/543db2ae-cc05-4a20-abb5-dc02be932451" />
