### PR TITLE
🐛 Fix supported types not showing on export modal

### DIFF
--- a/app/javascript/components/pages/Search/index.jsx
+++ b/app/javascript/components/pages/Search/index.jsx
@@ -23,7 +23,8 @@ const Search = ({
   bookmarkedQuestionIds,
   searchTerm,
   pagination,
-  filterMyQuestions
+  filterMyQuestions,
+  lms
 }) => {
   const { props: pageProps } = usePage()
   const currentUser = pageProps.currentUser
@@ -243,6 +244,7 @@ const Search = ({
         filterMyQuestions={filterMyQuestionsState}
         onFilterMyQuestionsToggle={handleFilterMyQuestionsToggle}
         currentUser={currentUser}
+        lms={lms}
       />
       <SearchFilters
         selectedSubjects={filterState.selectedSubjects}


### PR DESCRIPTION
At some point the supported types stopped showing.  This commit will fix that by passing the `lms` prop down to the `SearchResults` component, which in turn passes it to the `ExportModal` component.

Ref:
- https://github.com/notch8/viva/issues/530

<img width="877" height="605" alt="image" src="https://github.com/user-attachments/assets/d7431fce-d1df-49e4-a3c8-6856ee8631ed" />
