### PR TITLE
🐛 Fix child question deletion

### DIFF
--- a/app/models/question/stimulus_case_study.rb
+++ b/app/models/question/stimulus_case_study.rb
@@ -8,6 +8,8 @@ class Question::StimulusCaseStudy < Question
   self.model_exporter = 'stimulus_type'
   self.has_parts = true
 
+  before_destroy :destroy_child_questions
+
   has_many :as_parent_question_aggregations,
            class_name: "QuestionAggregation",
            inverse_of: :parent_question,
@@ -63,5 +65,9 @@ class Question::StimulusCaseStudy < Question
 
     combined_text = (texts + child_data).join(' ').squeeze(' ')
     self.searchable = final_scrub(combined_text)
+  end
+
+  def destroy_child_questions
+    child_questions.each(&:destroy)
   end
 end

--- a/spec/models/question/stimulus_case_study_spec.rb
+++ b/spec/models/question/stimulus_case_study_spec.rb
@@ -64,4 +64,20 @@ RSpec.describe Question::StimulusCaseStudy do
       expect(subject[1].keys).to match_array(["type_label", "type_name", "text", "data", "images"])
     end
   end
+
+  describe '#destroy_child_questions' do
+    it "destroys child questions when the StimulusCaseStudy is destroyed" do
+      stimulus_case_study = FactoryBot.create(:question_stimulus_case_study)
+      child_question_ids = stimulus_case_study.child_questions.pluck(:id)
+
+      expect do
+        stimulus_case_study.destroy
+      end.to change(Question::StimulusCaseStudy, :count).by(-1)
+                                                        .and change(Question, :count).by(-(child_question_ids.size + 1)) # +1 for the StimulusCaseStudy itself
+
+      child_question_ids.each do |cq_id|
+        expect(Question.find_by(id: cq_id)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit will add a before_destroy callback to the StimulusCaseStudy model to ensure that all associated child questions are deleted when a stimulus case study is destroyed which prevents orphaned questions.

Ref:
- https://github.com/notch8/viva/issues/533