### PR TITLE
:bug: Fix duplicate text in Essay and Upload question HTML content

### DIFF
--- a/app/models/concerns/markdown_question_behavior.rb
+++ b/app/models/concerns/markdown_question_behavior.rb
@@ -43,12 +43,12 @@ module MarkdownQuestionBehavior
         row.fetch("TEXT_#{integer}")
       end
 
-      # Combine TEXT with sections - TEXT becomes the leading paragraph
+      # Combine sections into HTML content. TEXT is stored separately in the text column,
+      # so we don't include it here to avoid duplication.
       # Why the double carriage return?  Without that if we have "Text\n* Bullet" that will be
       # converted to "<p>Text\n* Bullet</p>" But with the "\n\n" we end up with
       # "<p>Text</p><ul><li>Bullet</li></ul>"; and multiple bullets also work.
-      all_parts = [@text, *sections].compact
-      combined = all_parts.join("\n\n")
+      combined = sections.compact.join("\n\n")
 
       # Use Loofah with prune scrubber to remove unsafe tags AND their content (like script).
       # This is more aggressive than sanitize which keeps text content of stripped tags.

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -252,7 +252,7 @@ RSpec.shared_examples 'a Markdown Question' do
 
       it { is_expected.to be_valid }
       it { is_expected.not_to be_persisted }
-      let(:expected_html) { "<p>Title of Question</p><ul><li><p>Bullet Point</p></li><li><p>Second Point</p></li></ul>" }
+      let(:expected_html) { "<ul><li><p>Bullet Point</p></li><li><p>Second Point</p></li></ul>" }
       its(:data) { is_expected.to eq({ "html" => expected_html }) }
 
       it 'will save the underlying record' do


### PR DESCRIPTION
Remove TEXT field from HTML generation since it's already stored in the text column. Update specs to reflect correct behavior.

to confirm:

``` ruby
Question.destroy_all
bundle exec rake db:seed
Go to an essay or upload question. You shouldn't see duplicate TEXT fields displayed.
```

## BEFORE
<img width="2704" height="1462" alt="image" src="https://github.com/user-attachments/assets/a3351b57-5414-42a0-864d-b30261354a24" />

## AFTER

<img width="2704" height="1462" alt="image" src="https://github.com/user-attachments/assets/fc51e89e-d2d8-4251-ad20-aa29f99f5ae0" />
